### PR TITLE
RTL8191S WLAN based udev rules

### DIFF
--- a/filechanges/etc/udev/rules.d/10-usb-wifi.rules
+++ b/filechanges/etc/udev/rules.d/10-usb-wifi.rules
@@ -1,0 +1,3 @@
+# Needed to register vender and model id with r8712u driver
+
+ACTION=="add", SUBSYSTEM=="usb", ATTR{product}=="RTL8191S WLAN Adapter ", RUN+="/usr/local/bin/add_RTL8191S"

--- a/filechanges/usr/local/bin/add_RTL8191S
+++ b/filechanges/usr/local/bin/add_RTL8191S
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+ID_INTERFACE_FILE=/sys/bus/usb/drivers/r8712u/new_id
+
+if [[ -z $ID_VENDOR_ID || -z $ID_MODEL_ID ]]
+then
+	echo "No vendor or model to register"
+	exit 1
+fi 
+
+if ! lsmod | grep -q r8712u
+then
+	echo "Loading r8712u driver"
+	modprobe r8712u
+fi
+
+# wait for driver to settle
+sleep 5
+
+until [[ -f $ID_INTERFACE_FILE ]]
+do
+	echo "Waiting for r8712u to come up"
+	sleep 1
+done
+
+echo "Registering $ID_VENDOR_ID:$ID_MODEL_ID with r8712u driver"
+echo $ID_VENDOR_ID $ID_MODEL_ID > $ID_INTERFACE_FILE


### PR DESCRIPTION
- added udev rule triggering auxiliary script on USB add event
- added auxiliary script for driver loading and registering device and model ID
