### PR TITLE
Fix for Samba share problem and specifying the security mode

### DIFF
--- a/filechanges/opt/musicbox/startup.sh
+++ b/filechanges/opt/musicbox/startup.sh
@@ -306,11 +306,11 @@ done
 ntpdate ntp.ubuntu.com > /dev/null 2>&1 || true
 
 #mount windows share
-if [ "$INI__network__network_mount_address" != "" ]
+if [ "$INI__network__mount_address" != "" ]
 then
     #mount samba share, readonly
     log_progress_msg "Mounting Windows Network drive..." "$NAME"
-    mount -t cifs -o ro,rsize=2048,wsize=4096,cache=strict,user=$INI__network__network_mount_user,password=$INI__network__network_mount_password $INI__network__network_mount_address /music/Network/
+    mount -t cifs -o sec=ntlm,ro,rsize=2048,wsize=4096,cache=strict,user=$INI__network__mount_user,password=$INI__network__mount_password $INI__network__network_mount_address /music/Network/
 #add rsize=2048,wsize=4096,cache=strict because of usb (from raspyfi)
 fi
 


### PR DESCRIPTION
Samba shares were never mounted due to an incorrect variable name. Specifying the security mode seems to help in connecting to Apple TimeCapsules.
