### PR TITLE
Windows CIFS mounting from mopidy user

### DIFF
--- a/filechanges/opt/musicbox/startup.sh
+++ b/filechanges/opt/musicbox/startup.sh
@@ -145,7 +145,9 @@ if [ "$INI__network__mount_address" != "" ]
 then
     #mount samba share, readonly
     log_progress_msg "Mounting Windows Network drive..." "$NAME"
-    mount -t cifs -o sec=ntlm,ro,user=$INI__network__mount_user,password=$INI__network__mount_password $INI__network__mount_address /music/Network/
+    MOUNT_UID=$(id -u mopidy)
+    MOUNT_GID=$(getent group mopidy | cut -d: -f3)
+    mount -t cifs -o sec=ntlm,ro,user=$INI__network__mount_user,password=$INI__network__mount_password,uid=$MOUNT_UID,gid=$MOUNT_GID,iocharset=utf8 $INI__network__mount_address /music/Network/
 #    mount -t cifs -o sec=ntlm,ro,rsize=2048,wsize=4096,cache=strict,user=$INI__network__mount_user,password=$INI__network__mount_password $INI__network__mount_address /music/Network/
 #add rsize=2048,wsize=4096,cache=strict because of usb (from raspyfi)
 fi


### PR DESCRIPTION
Adding uid and gid of the mopidy user will allow it to access files on the mounted CIFS share.
Also added iocharset=utf8 to support files and directories with non-english chars in their names.
