### PR TITLE
Update setsound.sh

### DIFF
--- a/filechanges/opt/musicbox/setsound.sh
+++ b/filechanges/opt/musicbox/setsound.sh
@@ -50,7 +50,7 @@ function enumerate_alsa_cards()
                     elif [[ ${dev[1]} == "snd-hifiberry-digi" ]]; then
                         I2S_CARD=$num
                     # hifiberry dac+
-                    elif [[ ${dev[1]} == "snd-hifiberry-dacplus" ]]; then
+                    elif [[ ${dev[1]} == "snd-rpi-hifiberry-dacplus" ]]; then
                         I2S_CARD=$num
                     # iq audio
                     elif [[ ${dev[1]} == "snd-rpi-iqaudio-dac" ]]; then


### PR DESCRIPTION
Hifiberry DAC+ works with this change on RPI B+ and 0.5.1b. I don't know about the other Hifiberry devices.