### PR TITLE
Change read_ini.sh to use associative arrays

### DIFF
--- a/Create Pi MusicBox.rst
+++ b/Create Pi MusicBox.rst
@@ -197,7 +197,7 @@ Update the kernel to make sure all optimizations of newer core-software:
 
 **USB Fix**
 
-It's tricky to get good sound out of the Pi. For USB Audio (sound cards, etc), it is essential to disable the so called FIQ_SPLIT. Why? It seems that audio at high nitrates interferes with the ethernet activity, which also runs over USB. Add these options to the cmdline.txt file on your SD Card.
+It's tricky to get good sound out of the Pi. For USB Audio (sound cards, etc), it is essential to disable the so called FIQ_SPLIT. Why? It seems that audio at high bitrates interferes with the ethernet activity, which also runs over USB. Add these options to the cmdline.txt file on your SD Card.
 
     dwc_otg.fiq_fix_enable=1 dwc_otg.fiq_split_enable=0
 

--- a/create_musicbox.sh
+++ b/create_musicbox.sh
@@ -108,7 +108,7 @@ ln -fsn /boot/config/settings.ini /var/lib/mopidy/.config/mopidy/mopidy.conf
 #**USB Fix**
 #It's tricky to get good sound out of the Pi. For USB Audio (sound cards, etc),
 # it is essential to disable the so called FIQ_SPLIT. Why? It seems that audio
-# at high nitrates interferes with the ethernet activity, which also runs over USB.
+# at high bitrates interferes with the ethernet activity, which also runs over USB.
 # These options are added at the beginning of the cmdline.txt file in /boot
 sed -i '1s/^/dwc_otg.fiq_fix_enable=1 dwc_otg.fiq_split_enable=0 smsc95xx.turbo_mode=N /' /boot/cmdline.txt
 

--- a/filechanges/boot/config/settings.ini
+++ b/filechanges/boot/config/settings.ini
@@ -96,7 +96,7 @@ deviceid =
 # -----------
 # https://github.com/dz0ny/mopidy-youtube
 # Play music from Youtube
-[gmusic]
+[youtube]
 enabled = true
 
 # ----------

--- a/filechanges/boot/config/settings.ini
+++ b/filechanges/boot/config/settings.ini
@@ -5,6 +5,7 @@
 # Edit the settings of your MusicBox and the Mopidy music server here
 # This is a file read by both the MusicBox startup-scripts and Mopidy.
 # For more info on the settings of Mopidy: http://docs.mopidy.com/en/latest/config/
+# or the particular extenion's GitHub page 
 #
 # Every line starting with a # is a comment, it does not do anything until you remove the #
 
@@ -12,7 +13,7 @@
 # | Network Settings |
 # --------------------
 [network]
-# settings of your Wifi network, if you use a (supported) wifi-dongle
+# Settings for your WiFi network, if you use a (supported) wifi-dongle
 # Only supports WPA security, no WEP or access points without security (dive into the command line for that!)
 wifi_network = 
 wifi_password = 
@@ -38,8 +39,7 @@ mount_password =
 # This will set the workgroup to the name you want
 workgroup = WORKGROUP
 
-# Enable SSH
-# Comment out this line (remove the #) to enable remote login via SSH on MusicBox
+# Enable this to allow remote login via SSH on MusicBox
 enable_ssh = false
 
 # By default, MusicBox waits for the network to come up, since there is not much to do without a network.
@@ -49,9 +49,9 @@ wait_for_network = true
 # -----------
 # | Spotify |
 # -----------
+# https://github.com/mopidy/mopidy-spotify
 [spotify]
-# Enable the service or not (true or false)
-# Set to true to enable Spotify and fill in your credentials
+# Supply your PREMIUM account credentials to enable Spotify
 enabled = false
 username = 
 password = 
@@ -60,12 +60,11 @@ bitrate = 320
 cache_dir = ""
 
 # -----------
-# | Last.FM |
+# | Last.fm |
 # -----------
+# https://github.com/mopidy/mopidy-scrobbler
+# Supply your credentials to scrobble tracks to Last.fm
 [scrobbler]
-# Enable this to let Last.FM track the tracks you played
-# Enable the service or not (true or false)
-# Set to true to enable Last.FM and fill in your credentials
 enabled = false
 username = 
 password = 
@@ -73,28 +72,19 @@ password =
 # --------------
 # | SoundCloud |
 # --------------
+# https://github.com/mopidy/mopidy-soundcloud
+# Supply your auth_token obtained from http://www.mopidy.com/authenticate
 [soundcloud]
-# SoundCloud Settings (beta!)
-# Edit this if you want to add soundcloud support. You have to get a token via http://www.mopidy.com/authenticate
-# and fill it in here e.g.
-# auth_token = 1-1111-1111111
 enabled = false
 auth_token = 
-# The number of songs in the list
-explore_songs = 30
 
 # ----------------
 # | Google Music |
 # ----------------
+# https://github.com/hechtus/mopidy-gmusic
+# Supply your credentials to enable Google Music
+# NOTE: If enabled this may slow down the start of MusicBox. Please be patient
 [gmusic]
-# Google Music Settings (beta!)
-# The device ID is a 16-digit hexadecimal string (without a '0x' prefix) identifying the Android device registered for Google Play Music.
-# You can obtain this ID by dialing *#*#8255#*#* on your phone (see the aid) or using an app like Android Device ID (see the Google Service Framework ID Key).
-# You may also leave this field empty. MusicBox will try to find the ID by itself. See the Mopidy logs for more information.
-# More info at https://github.com/hechtus/mopidy-gmusic
-# Enable the service or not (true or false)
-# Set to true to enable Google Music
-# NOTE: This can slowdown the start of MusicBox. Please be patient when it starts.
 enabled = false
 all_access = true
 username  = 
@@ -104,14 +94,9 @@ deviceid =
 # ----------
 # | Dirble |
 # ----------
+# https://github.com/mopidy/mopidy-dirble
+# Play radio stations from Dirble
 [dirble]
-# Edit this if you want to add Dirble, browsing of international radiostations. 
-# Optionally you can get an api-key by creating an account at http://www.dirble.com/
-# Then go to the section 'Your API-Keys' and copy the key you see
-# and fill it in here e.g:
-# api_key = 473279e3fa0e7010cbbbb40ecc31890d46e57a2e
-# Enable the service or not (true or false)
-# Set to true to enable Dirble
 enabled = true
 api_key = 473279e3fa0e7010cbbbb40ecc31890d46e57a2e
 countries = US, NL, DE, NO, SE
@@ -119,54 +104,38 @@ countries = US, NL, DE, NO, SE
 # ------------
 # | Subsonic |
 # ------------
+# https://github.com/rattboi/mopidy-subsonic
+# Stream music from your Subsonic Music Streamer
 [subsonic]
-# Edit these lines for Subsonic support
-# Set the hostname = some.website.com (leave off http/https)
-# Enable the service or not (true or false)
-# Set to true to enable Subsonic
 enabled = false
 hostname = 
-# Set the port. e.g. port = 8888
 port = 
 username = 
 password = 
-# SSL yes or no
 ssl = 
 
 # ----------------
-# | Tunein Radio |
+# | TuneIn Radio |
 # ----------------
+# https://github.com/kingosticks/mopidy-tunein
+# Play radio stations from TuneIn
 [tunein]
 enabled = true
-timeout = 5000
 
 # ------------------------
 # | The Internet Archive |
 # ------------------------
-[internetarchive]
+# http://mopidy-internetarchive.readthedocs.org/en/latest/config.html
 # Listen to sounds and music from the Internet Archive
-# For more info see http://mopidy-internetarchive.readthedocs.org/en/latest/
+[internetarchive]
 enabled = false
-# archive.org base URL
-#base_url = http://archive.org
-# collections for searching/browsing
-#collections = audio, audio_bookspoetry, audio_foreign, audio_music, audio_news, audio_podcast
-# media types for searching/browsing
-#mediatypes = audio, etree
-# audio file formats, in order of preference
-#formats = VBR MP3, MP3
-# sort order for browsing: <fieldname> (asc|desc)
-# fieldnames: avg_rating creatorSorter date downloads month public date stars titleSorter week year
-#browse_order = creatorSorter desc
 
 # -----------
 # | Soma FM |
 # -----------
+# https://github.com/AlexandrePTJ/mopidy-somafm
+# Play radio stations from Soma FM
 [somafm]
-# Play radiostations from Soma FM
-# see https://github.com/AlexandrePTJ/mopidy-somafm
-# SomaFM does not provide every possible combinaton of encoding and quality.
-# In example, on the date of 2014/03/15, mp3 + highest gives only 3 playlists while mp3 + fast gives 29
 enabled = false
 encoding = mp3
 quality = fast
@@ -174,39 +143,22 @@ quality = fast
 # -----------
 # | Podcast |
 # -----------
+# https://github.com/tkem/mopidy-podcast
+# Play podcasts from different sources
 [podcast]
-# Play Podcasts from different sources
-# See https://github.com/tkem/mopidy-podcast
-# TODO: You cannot add settings for [podcast-itunes] or [podcast-gpodder]
+# Note: You cannot add settings for [podcast-itunes] or [podcast-gpodder]
 # because it breaks the startup script (won't read dashes in section names
 enabled = true
-# podcast update interval in seconds
-##update_interval = 86400
-# sort order: asc (oldest first) or desc (newest first)
-##sort_order = desc
-# Add feeds here
 feeds = 
 
 # ---------------
 # | AudioAddict |
 # ---------------
+# https://github.com/nilicule/mopidy-audioaddict
+# Play music from all the AudioAddict network of sites (login optional)
 [audioaddict]
-# enable plugin
 enabled = false
-# username (email) and password (optional)
-#username =
-#password =
-# you need an account if you want to set stream quality
-# valid options are:
-#   40k, 64k (free)
-#   40k, 64k, 128k, 320k (premium)
-quality = 64k
-# enable or disable individual stations
-difm = true
-radiotunes = true
-rockradio = true
-jazzradio = true
-frescaradio = true
+
 
 # ---------------------
 # | MusicBox Settings |
@@ -216,25 +168,21 @@ frescaradio = true
 # For security, the value in this file will be automatically cleaned out when the password is set in MusicBox
 root_password = 
 
-# Uncomment this one to let MusicBox automatically resize the filesystem 
-# of your SD Card, so the system uses all the space of your card. Recommended because otherwise the card might fill up. 
-# This is beta, you can lose data on your card if you enable this!!  
+# Automatically resize the filesystem and use all available space on your SD card. 
+# Use at your own risk, you could lose data on your card.  
 # (If so, you can put the original MusicBox image on it again and start over) 
 resize_once = true
 
-# Uncomment this setting to let Mopidy/MusicBox scan on startup for new music files 
-# on the card or the network (could take a while!)
-# Local files works ok for moderate size collections. Large sizes could give problems.
-# IMPORTANT: if you set ALWAYS to true, this scan happens every boot.
-# This can slowdown the boot a lot. Disable it again if your music doesn't change, or
-# use ONCE to, yes, scan your music files only once.
+# Scan on startup for new music files on the SD card or the network shares (could take a while!).
+# Local files work ok for moderate size collections. Large music database sizes could cause problems.
+# IMPORTANT: if you enable scan_always this will scan on every boot.
+# If your music doesn't change or you only stream music set scan_once instead. 
 #scan_once = true
 scan_always = true
 
 # MusicBox can automatically start playing a stream/song after startup.
-# It will wait a number of seconds before trying to play,
-# to give the system (Mopidy) time to start. Since this time can vary per device, network and configuration,
-# you can also set the number of seconds. If it does not work, give the system more time, e.g. 60 seconds.
+# It will wait a number of seconds before trying to do so for the system to first become ready. 
+# The wait required varies per device, network and configuration so if it doesn't work then increase the time.
 # e.g. autoplay = http://nprdmp.ic.llnwd.net/stream/nprdmp_live01_mp3 or local:track:MusicBox/Music%20File.mp3 (on the SD Card)
 autoplay = 
 autoplaywait = 60
@@ -242,8 +190,8 @@ autoplaywait = 60
 # -------------
 # | Streaming |
 # -------------
-# Set these options to True to enable streaming to Pi MusicBox here.
-# AirTunes (using Shairport):
+# Set these options to enable streaming to Pi MusicBox
+# AirTunes (using Shairport-sync):
 enable_shairport = 
 
 # DLNA/uPnP/OpenHome (using upmpdcli):
@@ -255,10 +203,10 @@ enable_upnp =
 # Because of limitations with some USB-DACs, MusicBox downsamples USB sound to 44k by default. Set to false to disable.
 downsample_usb = true
 
-# Set default output. This overrides the automatic detection (which sets to usb audio if an usb audio device
-# is found, else to hdmi (if hdmi is connected at boot), and otherwise just to the analog out)
-# i2s (HifiBerry et all) is not detected automatically. Set it here to be able to use it. 
-# Options: analog, hdmi, usb, hifiberry_dac, hifiberry_digi, hifiberry_dacplus, iqaudio_dac, wolfson (wolfson needs different kernel)
+# Set default audio output. This overrides the automatic detection (which sets to usb audio if an usb audio device
+# is found, else to hdmi (if hdmi is connected at boot), and otherwise just to the analog out).
+# i2s cards (e.g. HifiBerry etc) are not detected automatically and must be explicitly set here.
+# Options: analog, hdmi, usb, hifiberry_dac, hifiberry_digi, hifiberry_dacplus, hifiberry_amp, iqaudio_dac
 output = 
 
 [audio]
@@ -280,15 +228,14 @@ output = alsasink
 
 mixer = software
 
-#optionally, you can use alsamixer. This enables you to use hardware mixers of usb/audiocards.
-#Set the previous setting to:
+# Optionally, you can use alsamixer. This enables you to use hardware mixers of usb/audiocards.
+# Set the previous setting to:
 #mixer = alsamixer
-#And set the card and contol below. E.g. 
+# And set the card and contol below. E.g. 
 #card = 1 
 #control = Master 
-#Run the command 'amixer scontrols' from the commandline to list available controls on your system
-#See https://github.com/mopidy/mopidy-alsamixer 
-
+# Run the command 'amixer scontrols' from the commandline to list available controls on your system
+# See https://github.com/mopidy/mopidy-alsamixer
 [alsamixer]
 card = 
 control = 
@@ -317,7 +264,7 @@ static_dir = /opt/webclient
 [websettings]
 enabled = true
 musicbox = true
-config_file  = /boot/config/settings.ini
+config_file = /boot/config/settings.ini
 
 [mpd]
 hostname = 0.0.0.0
@@ -336,8 +283,6 @@ data_dir = /var/lib/mopidy/localdata
 # TODO: You cannot add settings for [local-sqlite]
 # because it breaks the startup script (won't read dashes in section names
 library = sqlite
-#library = whoosh
-#library = json
 
 scan_timeout = 1000
 scan_flush_threshold = 1000

--- a/filechanges/boot/config/settings.ini
+++ b/filechanges/boot/config/settings.ini
@@ -17,9 +17,11 @@
 wifi_network = 
 wifi_password = 
 
-# Set the name of the MusicBox. In this way you can create different devices on the same network (in different rooms).
-# The webinterface is accessible via e.g. http://kitchen.local/, and multiple devices will show up in AirTunes
-# You can only use normal characters and numbers in the name (no spaces, dots, etc)
+# Set the name of the MusicBox. 
+# In this way you can identify and access different devices on the same network e.g. across different rooms.
+# A MusicBox device named kitchen would be accessible from a web browser at http://kitchen.local/, from an MPD 
+# client at kitchen.local and advertised as kitchen on AirTunes.
+# The name is restricted to a maximum of 9 alphanumeric characters (no spaces, dots, etc).
 # You can even have different devices with different Spotify accounts when needed.
 name = MusicBox
 

--- a/filechanges/boot/config/settings.ini
+++ b/filechanges/boot/config/settings.ini
@@ -91,6 +91,14 @@ username  =
 password = 
 deviceid = 
 
+# -----------
+# | YouTube |
+# -----------
+# https://github.com/dz0ny/mopidy-youtube
+# Play music from Youtube
+[gmusic]
+enabled = true
+
 # ----------
 # | Dirble |
 # ----------

--- a/filechanges/boot/config/settings.ini
+++ b/filechanges/boot/config/settings.ini
@@ -244,9 +244,6 @@ control =
 enabled = true
 protocols = http, https, mms, file, rtmp, rtmps, rtsp, udp, mmsh
 
-[mpris]
-enabled = false
-
 [http]
 enabled = true
 hostname = 0.0.0.0

--- a/filechanges/boot/config/settings.ini
+++ b/filechanges/boot/config/settings.ini
@@ -285,11 +285,44 @@ playlists_dir = /var/lib/mopidy/playlists
 data_dir = /var/lib/mopidy/localdata
 #This sets the method of indexing local files
 #You can set it to json or whoosh. Whoosh might be better with large collections, JSON is a bit more mature.
-# TODO: You cannot add settings for [local-sqlite]
-# because it breaks the startup script (won't read dashes in section names
 library = sqlite
 
 scan_timeout = 1000
-scan_flush_threshold = 1000
+scan_flush_threshold = 100
 excluded_file_extensions = .html, .jpeg, .jpg, .log, .nfo, .png, .txt, .mkv, .avi, .divx, .qt, .wmv, .htm, .zip, .rar, .gz, .pdf, .exe, .ini, .mid, .db, .m3u, .sfv, .midi
 
+[local-sqlite]
+enabled = true
+
+# NOTE: Handling of complex parameters (e.g. that contain spaces and do not contain '=') are not
+#       currently handled properly by read_ini.sh. Commented out this section in order to revert
+#       to using default values instead.
+#       (see https://github.com/rudimeier/bash_ini_parser/issues/2 for details
+# top-level directories for browsing, as <name> <uri>
+#directories =
+#    Albums                  local:directory?type=album
+#    Artists                 local:directory?type=artist
+#    Composers               local:directory?type=artist&role=composer
+#    Folders                 local:directory:
+#    Genres                  local:directory?type=genre
+#    Performers              local:directory?type=artist&role=performer
+#    Release Years           local:directory?type=date&format=%25Y
+#    Tracks                  local:directory?type=track
+#    Last Week's Updates     local:directory?max-age=604800
+#    Last Month's Updates    local:directory?max-age=2592000
+
+# database connection timeout in seconds
+timeout = 10
+
+# whether to use an album's musicbrainz_id for generating its URI
+use_album_mbid_uri = true
+
+# whether to use an artist's musicbrainz_id for generating its URI;
+# disabled by default, since some taggers do not handle this well for
+# multi-artist tracks [https://github.com/sampsyo/beets/issues/907]
+use_artist_mbid_uri = false
+
+# override search limit provided by Mopidy core; set to -1 (no limit)
+# to emulate current behavior of json library
+# [https://github.com/mopidy/mopidy/issues/917]
+search_limit = -1

--- a/filechanges/opt/musicbox/read_ini.sh
+++ b/filechanges/opt/musicbox/read_ini.sh
@@ -11,281 +11,275 @@
 #
 
 
-#function read_config_file()
-#{
 
-##convert windows ini to unix
-#dos2unix -n $1 /tmp/settings.ini > /dev/null 2>&1 || true
-
-## ini vars to mopidy settings
-#read_ini /tmp/settings.ini MusicBox
-
-#rm /tmp/settings.ini > /dev/null 2>&1 || true
-
-#}
 
 function read_ini()
 {
-    # Be strict with the prefix, since it's going to be run through eval
-    function check_prefix()
-    {
-	if ! [[ "${VARNAME_PREFIX}" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]] ;then
-	    echo "read_ini: invalid prefix '${VARNAME_PREFIX}'" >&2
-	    return 1
-	fi
-    }
-    
-    function check_ini_file()
-    {
-	if [ ! -r "$INI_FILE" ] ;then
-	    echo "read_ini: '${INI_FILE}' doesn't exist or not" \
-		"readable" >&2
-	    return 1
-	fi
-    }
-    
-    # enable some optional shell behavior (shopt)
-    function pollute_bash()
-    {
-	if ! shopt -q extglob ;then
-	    SWITCH_SHOPT="${SWITCH_SHOPT} extglob"
-	fi
-	if ! shopt -q nocasematch ;then
-	    SWITCH_SHOPT="${SWITCH_SHOPT} nocasematch"
-	fi
-	shopt -q -s ${SWITCH_SHOPT}
-    }
-    
-    # unset all local functions and restore shopt settings before returning
-    # from read_ini()
-    function cleanup_bash()
-    {
-	shopt -q -u ${SWITCH_SHOPT}
-	unset -f check_prefix check_ini_file pollute_bash cleanup_bash
-    }
-    
-    local INI_FILE=""
-    local INI_SECTION=""
-
-    # {{{ START Deal with command line args
-
-    # Set defaults
-    local BOOLEANS=1
-    local VARNAME_PREFIX=INI
-    local CLEAN_ENV=0
-
-    # {{{ START Options
-
-    # Available options:
-    #	--boolean		Whether to recognise special boolean values: ie for 'yes', 'true'
-    #					and 'on' return 1; for 'no', 'false' and 'off' return 0. Quoted
-    #					values will be left as strings
-    #					Default: on
-    #
-    #	--prefix=STRING	String to begin all returned variables with (followed by '__').
-    #					Default: INI
-    #
-    #	First non-option arg is filename, second is section name
-
-    while [ $# -gt 0 ]
-    do
-
-	case $1 in
-
-	    --clean | -c )
-		CLEAN_ENV=1
-	    ;;
-
-	    --booleans | -b )
-		shift
-		BOOLEANS=$1
-	    ;;
-
-	    --prefix | -p )
-		shift
-		VARNAME_PREFIX=$1
-	    ;;
-
-	    * )
-		if [ -z "$INI_FILE" ]
-		then
-		    INI_FILE=$1
-		else
-		    if [ -z "$INI_SECTION" ]
-		    then
-			INI_SECTION=$1
-		    fi
+	# Be strict with the prefix, since it's going to be run through eval
+	function check_prefix()
+	{
+		if ! [[ "${VARNAME_PREFIX}" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]] ;then
+			echo "read_ini: invalid prefix '${VARNAME_PREFIX}'" >&2
+			return 1
 		fi
-	    ;;
+	}
+	
+	function check_ini_file()
+	{
+		if [ ! -r "$INI_FILE" ] ;then
+			echo "read_ini: '${INI_FILE}' doesn't exist or not" \
+				"readable" >&2
+			return 1
+		fi
+	}
+	
+	# enable some optional shell behavior (shopt)
+	function pollute_bash()
+	{
+		if ! shopt -q extglob ;then
+			SWITCH_SHOPT="${SWITCH_SHOPT} extglob"
+		fi
+		if ! shopt -q nocasematch ;then
+			SWITCH_SHOPT="${SWITCH_SHOPT} nocasematch"
+		fi
+		shopt -q -s ${SWITCH_SHOPT}
+	}
+	
+	# unset all local functions and restore shopt settings before returning
+	# from read_ini()
+	function cleanup_bash()
+	{
+		shopt -q -u ${SWITCH_SHOPT}
+		unset -f check_prefix check_ini_file pollute_bash cleanup_bash
+	}
+	
+	local INI_FILE=""
+	local INI_SECTION=""
 
-	esac
+	# {{{ START Deal with command line args
 
-	shift
-    done
+	# Set defaults
+	local BOOLEANS=1
+	local VARNAME_PREFIX=INI
+	local CLEAN_ENV=0
 
-    if [ -z "$INI_FILE" ] && [ "${CLEAN_ENV}" = 0 ] ;then
-	echo -e "Usage: read_ini [-c] [-b 0| -b 1]] [-p PREFIX] FILE"\
-	    "[SECTION]\n  or   read_ini -c [-p PREFIX]" >&2
-	cleanup_bash
-	return 1
-    fi
+	# {{{ START Options
 
-    if ! check_prefix ;then
-	cleanup_bash
-	return 1
-    fi
+	# Available options:
+	#	--boolean		Whether to recognise special boolean values: ie for 'yes', 'true'
+	#					and 'on' return 1; for 'no', 'false' and 'off' return 0. Quoted
+	#					values will be left as strings
+	#					Default: on
+	#
+	#	--prefix=STRING	String to begin all returned variables with (followed by '__').
+	#					Default: INI
+	#
+	#	First non-option arg is filename, second is section name
 
-    local INI_ALL_VARNAME="${VARNAME_PREFIX}__ALL_VARS"
-    local INI_ALL_SECTION="${VARNAME_PREFIX}__ALL_SECTIONS"
-    local INI_NUMSECTIONS_VARNAME="${VARNAME_PREFIX}__NUMSECTIONS"
-    if [ "${CLEAN_ENV}" = 1 ] ;then
-	eval unset "\$${INI_ALL_VARNAME}"
-    fi
-    unset ${INI_ALL_VARNAME}
-    unset ${INI_ALL_SECTION}
-    unset ${INI_NUMSECTIONS_VARNAME}
+	while [ $# -gt 0 ]
+	do
 
-    if [ -z "$INI_FILE" ] ;then
-	cleanup_bash
-	return 0
-    fi
-    
-    if ! check_ini_file ;then
-	cleanup_bash
-	return 1
-    fi
+		case $1 in
 
-    # Sanitise BOOLEANS - interpret "0" as 0, anything else as 1
-    if [ "$BOOLEANS" != "0" ]
-    then
-	BOOLEANS=1
-    fi
+			--clean | -c )
+				CLEAN_ENV=1
+			;;
+
+			--booleans | -b )
+				shift
+				BOOLEANS=$1
+			;;
+
+			--prefix | -p )
+				shift
+				VARNAME_PREFIX=$1
+			;;
+
+			* )
+				if [ -z "$INI_FILE" ]
+				then
+					INI_FILE=$1
+				else
+					if [ -z "$INI_SECTION" ]
+					then
+						INI_SECTION=$1
+					fi
+				fi
+			;;
+
+		esac
+
+		shift
+	done
+
+	if [ -z "$INI_FILE" ] && [ "${CLEAN_ENV}" = 0 ] ;then
+		echo -e "Usage: read_ini [-c] [-b 0| -b 1]] [-p PREFIX] FILE"\
+			"[SECTION]\n  or   read_ini -c [-p PREFIX]" >&2
+		cleanup_bash
+		return 1
+	fi
+
+	if ! check_prefix ;then
+		cleanup_bash
+		return 1
+	fi
+
+	local INI_NUMSECTIONS_VARNAME="${VARNAME_PREFIX}__NUMSECTIONS"
+	if [ "${CLEAN_ENV}" = 1 ] ;then
+		# TODO How to clear the whole array without unset it
+		for i in "${!INI[@]}" ;do
+			unset ${VARNAME_PREFIX}['$i']
+		done
+	fi
+
+	# TODO How to declare -A ${VARNAME_PREFIX} non local? Or we have to
+	# check for a global declared one
+	unset ${INI_NUMSECTIONS_VARNAME}
+
+	if [ -z "$INI_FILE" ] ;then
+		cleanup_bash
+		return 0
+	fi
+	
+	if ! check_ini_file ;then
+		cleanup_bash
+		return 1
+	fi
+
+	# Sanitise BOOLEANS - interpret "0" as 0, anything else as 1
+	if [ "$BOOLEANS" != "0" ]
+	then
+		BOOLEANS=1
+	fi
 
 
-    # }}} END Options
+	# }}} END Options
 
-    # }}} END Deal with command line args
+	# }}} END Deal with command line args
 
-    local LINE_NUM=0
-    local SECTIONS_NUM=0
-    local SECTION=""
-    
-    # IFS is used in "read" and we want to switch it within the loop
-    local IFS=$' \t\n'
-    local IFS_OLD="${IFS}"
-    
-    # we need some optional shell behavior (shopt) but want to restore
-    # current settings before returning
-    local SWITCH_SHOPT=""
-    pollute_bash
-    
-    while read -r line || [ -n "$line" ]
-    do
+	local LINE_NUM=0
+	local SECTIONS_NUM=0
+	local SECTION=""
+	
+	# IFS is used in "read" and we want to switch it within the loop
+	local IFS=$' \t\n'
+	local IFS_OLD="${IFS}"
+	
+	# we need some optional shell behavior (shopt) but want to restore
+	# current settings before returning
+	local SWITCH_SHOPT=""
+	pollute_bash
+	
+	while read -r line || [ -n "$line" ]
+	do
 #echo line = "$line"
 
-	((LINE_NUM++))
+		((LINE_NUM++))
 
-	# Skip blank lines and comments
-	if [ -z "$line" -o "${line:0:1}" = ";" -o "${line:0:1}" = "#" ]
-	then
-	    continue
-	fi
+		# Skip blank lines and comments
+		if [ -z "$line" -o "${line:0:1}" = ";" -o "${line:0:1}" = "#" ]
+		then
+			continue
+		fi
 
-	# Section marker?
-	if [[ "${line}" =~ ^\[[a-zA-Z0-9_]{1,}\]$ ]]
-	then
+		# Section marker?
+		if [[ "${line}" =~ ^\[.*\]$ ]]
+		then
+			# Set SECTION var to name of section (strip [ and ] from section marker)
+			SECTION="${line#[}"
+			SECTION="${SECTION%]}"
+			read SECTION <<<"${SECTION}"
+			if ! [[ "${line}" =~ ^[[:print:]]+$  ]] ;then
+				echo "Error: Invalid section:" >&2
+				echo " ${LINE_NUM}: '$line'" >&2
+				cleanup_bash
+				return 1
+			fi
+			((SECTIONS_NUM++))
 
-	    # Set SECTION var to name of section (strip [ and ] from section marker)
-	    SECTION="${line#[}"
-	    SECTION="${SECTION%]}"
-	    eval "${INI_ALL_SECTION}=\"\${${INI_ALL_SECTION}# } $SECTION\""
-	    ((SECTIONS_NUM++))
+			continue
+		fi
 
-	    continue
-	fi
+		# Are we getting only a specific section? And are we currently in it?
+		if [ ! -z "$INI_SECTION" ]
+		then
+			if [ "$SECTION" != "$INI_SECTION" ]
+			then
+				continue
+			fi
+		fi
 
-	# Are we getting only a specific section? And are we currently in it?
-	if [ ! -z "$INI_SECTION" ]
-	then
-	    if [ "$SECTION" != "$INI_SECTION" ]
-	    then
-		continue
-	    fi
-	fi
-
-	# Valid var/value line? (check for variable name and then '=')
-	if ! [[ "${line}" =~ ^[a-zA-Z0-9._]{1,}[[:space:]]*= ]]
-	then
-	    echo "Error: Invalid line:" >&2
-	    echo " ${LINE_NUM}: $line" >&2
-	    cleanup_bash
-	    return 1
-	fi
+		# Valid var/value line? (check for variable name and then '=')
+		if ! [[ "${line}" =~ ^[[:print:]]+[[:space:]]*= ]]
+		then
+			echo "Error: Invalid line:" >&2
+			echo " ${LINE_NUM}: '$line'" >&2
+			cleanup_bash
+			return 1
+		fi
 
 
-	# split line at "=" sign
-	IFS="="
-	read -r VAR VAL <<< "${line}"
-	IFS="${IFS_OLD}"
+		# split line at "=" sign
+		IFS="="
+		read -r VAR VAL <<< "${line}"
+		IFS="${IFS_OLD}"
+		
+		# delete spaces around the equal sign (using extglob)
+		VAR="${VAR%%+([[:space:]])}"
+		VAL="${VAL##+([[:space:]])}"
+		VAR=$(echo $VAR)
+
+
+		# Construct variable name:
+		# ${VARNAME_PREFIX}__$SECTION__$VAR
+		# Or if not in a section:
+		# ${VARNAME_PREFIX}__$VAR
+		# In both cases, full stops ('.') are replaced with underscores ('_')
+		if [ -z "$SECTION" ]
+		then
+			VARNAME=${VAR//./_}
+		else
+			VARNAME=${SECTION}__${VAR//./_}
+		fi
+
+		if [[ "${VAL}" =~ ^\".*\"$  ]]
+		then
+			# remove existing double quotes
+			VAL="${VAL##\"}"
+			VAL="${VAL%%\"}"
+		elif [[ "${VAL}" =~ ^\'.*\'$  ]]
+		then
+			# remove existing single quotes
+			VAL="${VAL##\'}"
+			VAL="${VAL%%\'}"
+		elif [ "$BOOLEANS" = 1 ]
+		then
+			# Value is not enclosed in quotes
+			# Booleans processing is switched on, check for special boolean
+			# values and convert
+
+			# here we compare case insensitive because
+			# "shopt nocasematch"
+			case "$VAL" in
+				yes | true | on )
+					VAL=1
+				;;
+				no | false | off )
+					VAL=0
+				;;
+			esac
+		fi
+		
+#  		echo "pair: '${VARNAME}' = '${VAL}'"
+		eval ${VARNAME_PREFIX}$'[${VARNAME}]=${VAL}'
+# 		eval $'echo "array: \'${VARNAME}\' = \'${'${VARNAME_PREFIX}$'[${VARNAME}]}\'"'
+
+	done  <"${INI_FILE}"
 	
-	# delete spaces around the equal sign (using extglob)
-	VAR="${VAR%%+([[:space:]])}"
-	VAL="${VAL##+([[:space:]])}"
-	VAR=$(echo $VAR)
+	# return also the number of parsed sections
+	eval "$INI_NUMSECTIONS_VARNAME=$SECTIONS_NUM"
 
-
-	# Construct variable name:
-	# ${VARNAME_PREFIX}__$SECTION__$VAR
-	# Or if not in a section:
-	# ${VARNAME_PREFIX}__$VAR
-	# In both cases, full stops ('.') are replaced with underscores ('_')
-	if [ -z "$SECTION" ]
-	then
-	    VARNAME=${VARNAME_PREFIX}__${VAR//./_}
-	else
-	    VARNAME=${VARNAME_PREFIX}__${SECTION}__${VAR//./_}
-	fi
-	eval "${INI_ALL_VARNAME}=\"\${${INI_ALL_VARNAME}# } ${VARNAME}\""
-
-	if [[ "${VAL}" =~ ^\".*\"$  ]]
-	then
-	    # remove existing double quotes
-	    VAL="${VAL##\"}"
-	    VAL="${VAL%%\"}"
-	elif [[ "${VAL}" =~ ^\'.*\'$  ]]
-	then
-	    # remove existing single quotes
-	    VAL="${VAL##\'}"
-	    VAL="${VAL%%\'}"
-	elif [ "$BOOLEANS" = 1 ]
-	then
-	    # Value is not enclosed in quotes
-	    # Booleans processing is switched on, check for special boolean
-	    # values and convert
-
-	    # here we compare case insensitive because
-	    # "shopt nocasematch"
-	    case "$VAL" in
-		yes | true | on )
-		    VAL=1
-		;;
-		no | false | off )
-		    VAL=0
-		;;
-	    esac
-	fi
-	
-
-	# enclose the value in single quotes and escape any
-	# single quotes and backslashes that may be in the value
-	VAL="${VAL//\\/\\\\}"
-	VAL="\$'${VAL//\'/\'}'"
-
-	eval "$VARNAME=$VAL"
-    done  <"${INI_FILE}"
-    
-    # return also the number of parsed sections
-    eval "$INI_NUMSECTIONS_VARNAME=$SECTIONS_NUM"
-
-    cleanup_bash
+	cleanup_bash
 }
+
+

--- a/filechanges/opt/musicbox/setsound.sh
+++ b/filechanges/opt/musicbox/setsound.sh
@@ -125,6 +125,11 @@ case $OUTPUT in
         enumerate_alsa_cards $OUTPUT
         CARD=$I2S_CARD
         ;;
+    hifiberry_amp)
+        modprobe snd_soc_hifiberry_amp
+        enumerate_alsa_cards $OUTPUT
+        CARD=$I2S_CARD
+        ;;
     iqaudio_dac)
         modprobe snd_soc_pcm512x
         modprobe snd_soc_iqaudio_dac

--- a/filechanges/opt/musicbox/setsound.sh
+++ b/filechanges/opt/musicbox/setsound.sh
@@ -79,6 +79,10 @@ then
     # Convert windows ini to unix
     dos2unix -n $CONFIG_FILE /tmp/settings.ini > /dev/null 2>&1 || true
 
+    #declare $INI before reading ini https://github.com/rudimeier/bash_ini_parser/issues/2
+    unset INI
+    declare -A INI
+
     # ini vars to mopidy settings
     read_ini /tmp/settings.ini
 
@@ -88,7 +92,7 @@ fi
 # If output not defined, it will automatically detect USB / HDMI / Analog in given order
 # It is at this moment not possible to detect whether an i2s device is connected hence
 # i2s is only selected if explicitly given as output in the config file
-OUTPUT=$(echo $INI__musicbox__output | tr "[:upper:]" "[:lower:]")
+OUTPUT=$(echo ${INI["musicbox__output"]} | tr "[:upper:]" "[:lower:]")
 CARD=
 
 if [[ -z "$OUTPUT" ]]
@@ -171,7 +175,7 @@ fi
 
 log_progress_msg "Line out set to $OUTPUT card $CARD"
 
-if [ "$OUTPUT" == "usb" -a "$INI__musicbox__downsample_usb" == "1" ]
+if [ "$OUTPUT" == "usb" -a "${INI["musicbox__downsample_usb"]}" == "1" ]
 # resamples to 44K because of problems with some usb-dacs on 48k (probably related to usb drawbacks of Pi)
 # and extra buffer for usb
 #if [ "$OUTPUT" == "usb" ]

--- a/filechanges/opt/musicbox/startup.sh
+++ b/filechanges/opt/musicbox/startup.sh
@@ -39,7 +39,7 @@ INI_READ=true
 
 REBOOT=0
 
-if [ "$INI__musicbox__resize_once" == "1" ]
+if [ "${INI["musicbox__resize_once"]}" == "1" ]
 then
     #set resize_once=false in ini file
     sed -i -e "/^\[musicbox\]/,/^\[.*\]/ s|^\(resize_once[ \t]*=[ \t]*\).*$|\1false\r|" $CONFIG_FILE
@@ -51,7 +51,7 @@ fi
 #get name of device and trim
 HOSTNM=`cat /etc/hostname | tr -cd "[:alnum:]"`
 #get name in ini and trim
-CLEAN_NAME=$(echo $INI__network__name | tr -cd "[:alnum:]")
+CLEAN_NAME=$(echo ${INI["network__name"]} | tr -cd "[:alnum:]")
 #max 9 characters (max netbios length = 15, + '.local')
 CLEAN_NAME=$(echo $CLEAN_NAME | cut -c 1-9)
 
@@ -78,10 +78,10 @@ fi
 log_progress_msg "MusicBox name is $CLEAN_NAME" "$NAME"
 
 # do the change password stuff
-if [ "$INI__musicbox__root_password" != "" ]
+if [ "${INI["musicbox__root_password"]}" != "" ]
 then
     log_progress_msg "Setting root user Password" "$NAME"
-    echo "root:$INI__musicbox__root_password" | chpasswd
+    echo "root:${INI["musicbox__root_password"]}" | chpasswd
     #remove password
     sed -i -e "/^\[musicbox\]/,/^\[.*\]/ s|^\(root_password[ \t]*=[ \t]*\).*$|\1\r|" $CONFIG_FILE
 fi
@@ -89,15 +89,15 @@ fi
 #allow shutdown for all users
 chmod u+s /sbin/shutdown
 
-if [ "$INI__network__wifi_network" != "" ]
+if [ "${INI["network__wifi_network"]}" != "" ]
 then
     #put wifi settings for wpa roaming
 cat >/etc/wpa.conf <<EOF
     ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev
     update_config=1
     network={
-        ssid="$INI__network__wifi_network"
-        psk="$INI__network__wifi_password"
+        ssid="${INI["network__wifi_network"]}"
+        psk="${INI["network__wifi_password"]}"
         scan_ssid=1
     }
 EOF
@@ -112,10 +112,10 @@ fi
 #include code from setsound script
 . /opt/musicbox/setsound.sh
 
-if [ "$INI__network__workgroup" != "" ]
+if [ "${INI["network__workgroup"]}" != "" ]
 then
     #change smb.conf workgroup value
-    sed -i "s/workgroup = .*$/workgroup = $INI__network__workgroup/ig" /etc/samba/smb.conf
+    sed -i "s/workgroup = .*$/workgroup = ${INI["network__workgroup/ig"]}" /etc/samba/smb.conf
     #restart samba
     /etc/init.d/samba restart
 fi
@@ -124,7 +124,7 @@ fi
 iptables -t nat -A PREROUTING -p tcp --dport 80 -j REDIRECT --to-port 6680 > /dev/null 2>&1 || true
 
 # start SSH if enabled
-if [ "$INI__network__enable_ssh" == "1" ]
+if [ "${INI["network__enable_ssh"]}" == "1" ]
 then
     #create private keys for dropbear if they don't exist
     if [ ! -f "/etc/dropbear/dropbear_dss_host_key" ]
@@ -147,7 +147,7 @@ else
 fi
 
 # start upnp if enabled
-if [ "$INI__musicbox__enable_upnp" == "1" ]
+if [ "${INI["musicbox__enable_upnp"]}" == "1" ]
 then
     /etc/init.d/upmpdcli start
     ln -s /etc/monit/monitrc.d/upmpdcli /etc/monit/conf.d/upmpdcli > /dev/null 2>&1 || true
@@ -156,7 +156,7 @@ else
 fi
 
 # start shairport if enabled
-if [ "$INI__musicbox__enable_shairport" == "1" ]
+if [ "${INI["musicbox__enable_shairport"]}" == "1" ]
 then
     /etc/init.d/shairport-sync start
     ln -s /etc/monit/monitrc.d/shairport /etc/monit/conf.d/shairport > /dev/null 2>&1 || true
@@ -168,7 +168,7 @@ service monit start
 
 #check networking, sleep for a while
 MYIP=$(hostname -I)
-while [ "$MYIP" == "" -a "$INI__network__wait_for_network" != "0" ]
+while [ "$MYIP" == "" -a "${INI["network__wait_for_network"]}" != "0" ]
 do
     echo "Waiting for network..."
     echo
@@ -181,24 +181,24 @@ done
 ntpdate ntp.ubuntu.com > /dev/null 2>&1 || true
 
 #mount windows share
-if [ "$INI__network__mount_address" != "" ]
+if [ "${INI["network__mount_address"]}" != "" ]
 then
     #mount samba share, readonly
     log_progress_msg "Mounting Windows Network drive..." "$NAME"
-    mount -t cifs -o sec=ntlm,ro,user=$INI__network__mount_user,password=$INI__network__mount_password $INI__network__mount_address /music/Network/
-#    mount -t cifs -o sec=ntlm,ro,rsize=2048,wsize=4096,cache=strict,user=$INI__network__mount_user,password=$INI__network__mount_password $INI__network__mount_address /music/Network/
+    mount -t cifs -o sec=ntlm,ro,user=${INI["network__mount_user"]},password=${INI["network__mount_password"]} ${INI["network__mount_address"]} /music/Network/
+#    mount -t cifs -o sec=ntlm,ro,rsize=2048,wsize=4096,cache=strict,user=${INI["network__mount_user"]},password=${INI["network__mount_password"]} ${INI["network__mount_address"]} /music/Network/
 #add rsize=2048,wsize=4096,cache=strict because of usb (from raspyfi)
 fi
 
 # scan local music files once
-if [ "$INI__musicbox__scan_once" == "1" ]
+if [ "${INI["musicbox__scan_once"]}" == "1" ]
 then
     #set SCAN_ONCE = false
     sed -i -e "/^\[musicbox\]/,/^\[.*\]/ s|^\(scan_once[ \t]*=[ \t]*\).*$|\1false\r|" $CONFIG_FILE
 fi
 
 # scan local/networked music files if setting is true
-if [ "$INI__musicbox__scan_always" == "1" -o "$INI__musicbox__scan_once" == "1" ]
+if [ "${INI["musicbox__scan_always"]}" == "1" -o "${INI["musicbox__scan_once"]}" == "1" ]
 then
     log_progress_msg "Scanning music-files, please wait..."
     /etc/init.d/mopidy run local scan
@@ -210,9 +210,9 @@ fi
 #start mopidy
 /etc/init.d/mopidy start
 
-if [ "$INI__network__name" != "$CLEAN_NAME" -a "$INI__network__name" != "" ]
+if [ "${INI["network__name"]}" != "$CLEAN_NAME" -a "${INI["network__name"]}" != "" ]
 then
-    log_warning_msg "The new name of your MusicBox, $INI__network__name, is not ok! It should be max. 9 alphanumerical characters."
+    log_warning_msg "The new name of your MusicBox, ${INI["network__name"]}, is not ok! It should be max. 9 alphanumerical characters."
 fi
 
 # Print the IP address
@@ -224,17 +224,17 @@ fi
 # renice mopidy to 19, to have less stutter when playing tracks from spotify (at the start of a track)
 renice 19 `pgrep mopidy`
 
-if [ "$INI__musicbox__autoplay" -a "$INI__musicbox__autoplaywait" ]
+if [ "${INI["musicbox__autoplay"]}" -a "${INI["musicbox__autoplaywait"]}" ]
 then
-    log_progress_msg "Waiting $INI__musicbox__autoplaywait seconds before autoplay." "$NAME"
-    sleep $INI__musicbox__autoplaywait
-    log_progress_msg "Playing $INI__musicbox__autoplay" "$NAME"
-    mpc add "$INI__musicbox__autoplay"
+    log_progress_msg "Waiting ${INI["musicbox__autoplaywait"]} seconds before autoplay." "$NAME"
+    sleep ${INI["musicbox__autoplaywait"]}
+    log_progress_msg "Playing ${INI["musicbox__autoplay"]}" "$NAME"
+    mpc add "${INI["musicbox__autoplay"]}"
     mpc play
 fi
 
 
-# check and clean dirty bit of vfat partition not safely removed
+# check and clean dirty bit of vfat partition if not safely removed
 fsck /dev/mmcblk0p1 -v -a -w -p > /dev/null 2>&1 || true
 
 log_end_msg 0

--- a/site/faq.html
+++ b/site/faq.html
@@ -75,15 +75,20 @@ music box image, or is the only solution to use the whole new image?
 <span style="font-weight: bold;">A</span> <span style="font-weight: bold;">:</span> For now, there is
 no real upgrade path, and the only way to upgrade is to simply download
 the newest image.<br/>
-You could save your .ini and copy/paste settings to the new image.
+You could copy over your settings.ini and streamuris.js config files to the new image.
 <br>
 <div class="fadedline"></div>
 <span style="font-weight: bold;">Q</span> <span style="font-weight: bold;">:</span> <span style="font-weight: bold;">
-Can i use the free version of
+Can I use the free version of
 Spotify ? </span><br/><span style="font-weight: bold;">A</span>
-<span style="font-weight: bold;">:</span> No,
-sorry. Spotify does not allow free users to stream to third
-party clients.
+<span style="font-weight: bold;">:</span> No, 
+sorry. Spotify does not allow free users to stream to third party clients.
+<br>
+<div class="fadedline"></div>
+<span style="font-weight: bold;">Q</span> <span style="font-weight: bold;">:</span> <span style="font-weight: bold;">
+Can I use Spotify Connect ?</span><br/><span style="font-weight: bold;">A</span>
+<span style="font-weight: bold;">:</span> No, 
+sorry. Spotify has not released the API.
 <br>
 <div class="fadedline"></div>
 <span style="font-weight: bold;">Q</span> <span style="font-weight: bold;">:</span><span style="font-weight: bold;"> I upgraded
@@ -92,19 +97,13 @@ Can you advise me on what to do ?
 </span><br>
 <span style="font-weight: bold;">A</span> <span style="font-weight: bold;">:</span> I would
 advise you not to upgrade your Raspbian unless it is absolutely
-necessary, as
-it tends to cause breakage.<br>
+necessary, as it tends to cause breakage.<br>
 <div class="fadedline"></div>
-<span style="font-weight: bold;">Q</span> <span style="font-weight: bold;">:</span> <span style="font-weight: bold;">Can i change
-the standard radio
-station list ?
+<span style="font-weight: bold;">Q</span> <span style="font-weight: bold;">:</span> <span style="font-weight: bold;">
+Can I change the standard radio station list ?
 </span><br>
 <span style="font-weight: bold;">A :</span> Yes. <br>
-Currently the list is stored in
-/opt/defaultwebclient/js/functionsvars.js <br>
-(or opt\flatclient\js\functionsvars.js if accessing from a windows
-box),<br>
-which you can edit by hand with with any text editor.<br>
+Currently the list is stored in /boot/config/streamuris.js which you can edit by hand with any text editor.<br>
 You can also use any of the popular MPD clients on your phone/pc/mac, most of them have the option of storing playlists and radio stations locally. See <a href="http://mpd.wikia.com/wiki/Clients">http://mpd.wikia.com/wiki/Clients</a> for a suggested client list.
 <br>
 <div class="fadedline"></div>
@@ -112,8 +111,8 @@ You can also use any of the popular MPD clients on your phone/pc/mac, most of th
 Spotify radio ?
 </span><br>
 <span style="font-weight: bold;">B :</span>
-unfortunately Spotify's current libSpotify SDK does not support that
-function, if they implement it i'll try and include it.
+Unfortunately Spotify's current libSpotify SDK does not support that
+function, if they implement it I'll try and include it.
 <br>
 <div class="fadedline"></div>
 <span style="font-weight: bold;">Q :</span> <span style="font-weight: bold;">Can I
@@ -127,17 +126,17 @@ Output through i2s.
 <span style="font-weight: bold;">Q :</span> <span style="font-weight: bold;">Can I have
 several Musicboxes stream content to one another ? </span><br>
 <span style="font-weight: bold;">A :</span> Not yet,
-but i'm hoping to get it implemented one day.
+but I'm hoping to get it implemented one day.
 <br>
 <div class="fadedline"></div>
 <span style="font-weight: bold;">Q :</span> <span style="font-weight: bold;">Can i
 access the Pi via terminal/command line remotely ?
 </span><br>
 <span style="font-weight: bold;">A :</span> Yes,
-simply allow SSH in the Pi's .ini file.
+simply allow SSH in Pi Musicbox's settings.ini file.
 <br>
 <div class="fadedline"></div>
-<span style="font-weight: bold;">Q :</span> <span style="font-weight: bold;">Where can i
+<span style="font-weight: bold;">Q :</span> <span style="font-weight: bold;">Where can I
 find the hardcore technical info in Musicbox ?
 </span><br>
 <span style="font-weight: bold;">A :</span>
@@ -164,13 +163,13 @@ I may implement this if i ever have enough
 time, as it is a complicated project to get it working.
 <br>
 <div class="fadedline"></div>
-<span style="font-weight: bold;">Q :</span> <span style="font-weight: bold;">Can i edit my Spotify playlists
+<span style="font-weight: bold;">Q :</span> <span style="font-weight: bold;">Can I edit my Spotify playlists
 from the Musicbox ?</span><br>
 <span style="font-weight: bold;">A :</span> Once it
 is implemented in Mopidy, you'll be able to.
 <br>
 <div class="fadedline"></div>
-<span style="font-weight: bold;">Q :</span> <span style="font-weight: bold;">can i run the
+<span style="font-weight: bold;">Q :</span> <span style="font-weight: bold;">can I run the
 Musicbox output to
 several devices via a
 multi-channel USB audio device ?
@@ -184,9 +183,8 @@ list, sorry.
 <span style="font-weight: bold;">Q :</span> <span style="font-weight: bold;">Is there a
 support forum where i can ask in-depth questions ?
 </span><br>
-<span style="font-weight: bold;">A :</span> No,
-sorry, just Twitter and Facebook, as i don't &nbsp;have time for
-full-time support.<br>
+<span style="font-weight: bold;">A :</span> Yes, 
+<a href="https://discuss.mopidy.com/c/pi-musicbox">https://discuss.mopidy.com/c/pi-musicbox</a><br>
 <div class="fadedline"></div>
 <span style="font-weight: bold;">Q :</span> <span style="font-weight: bold;">Can i stream Spotify to several
 different Musicboxes at once ?</span>
@@ -195,14 +193,12 @@ different Musicboxes at once ?</span>
 this
 is a Spotify limitation.
 <br>
-But perhaps if i get around to implementing the streaming from Musicbox
+But perhaps if I get around to implementing the streaming from Musicbox
 to Musicbox, it may become possible.
 <br>
 <div class="fadedline"></div>
-<span style="font-weight: bold;">Q :</span> <span style="font-weight: bold;">Can i get the
-Musicbox to
-auto-start playing a playlist or
-radiostation upon bootup ?
+<span style="font-weight: bold;">Q :</span> <span style="font-weight: bold;">Can I get the
+Musicbox to auto-start playing a playlist or radio station upon bootup ?
 </span><br>
 <span style="font-weight: bold;">A :</span> Yes, use the settings page!
 <div class="fadedline"></div>

--- a/site/index.html
+++ b/site/index.html
@@ -113,7 +113,7 @@
                 <a href="http://mpd.wikia.com/wiki/Clients" target="_blank">MPD client</a> to connect.
             </li>
             <li>
-                Spotify <strong>Premium</strong>, Google Music (All Access) or SoundCloud account for streaming.
+                Spotify <strong>Premium</strong> (Spotify Connect is NOT supported), Google Music (All Access) or SoundCloud account for streaming.
             </li>
         </ul>
         <div class="fadedline"></div>


### PR DESCRIPTION
- Allows special characters to be used in section names of settings.ini.

- Adds support for configuring extensions like [local-sqlite] properly.

- Note that support for the ```search_limit``` parameter requires Mopidy-Local-SQLite >= 0.9.2 (run ```pip install --upgrade Mopidy-Local-SQLite``` to upgrade)