### PR TITLE
Configuration changes for switching to using nginx

### DIFF
--- a/Create Pi MusicBox.rst
+++ b/Create Pi MusicBox.rst
@@ -98,11 +98,9 @@ Network configuration:
 
 Webclient:
 
-Create a symlink from the package to the /opt/webclient and to /opt/defaultwebclient. This is done because you could install other webclients and just point the link to the newly installed client:
+Create a symlink from the package to the /opt/webclient:
 
     ln -fsn /usr/local/lib/python2.7/dist-packages/mopidy_musicbox_webclient/static /opt/webclient
-
-    ln -fsn /opt/webclient /opt/defaultwebclient
 
 Remove the streamuris.js and point it to the file in /boot/config
 

--- a/create_musicbox.sh
+++ b/create_musicbox.sh
@@ -57,9 +57,8 @@ chmod +x /etc/network/if-up.d/iptables
 chown root:root /etc/firewall/musicbox_iptables
 chmod 600 /etc/firewall/musicbox_iptables
 
-#Next, create a symlink from the package to the /opt/defaultwebclient.
+#Next, create a symlink from the package to the web client.
 ln -fsn /usr/local/lib/python2.7/dist-packages/mopidy_musicbox_webclient/static /opt/webclient
-ln -fsn /opt/webclient /opt/defaultwebclient
 
 #Remove the streamuris.js and point it to the file in /boot/config
 mv /usr/local/lib/python2.7/dist-packages/mopidy_musicbox_webclient/static/js/streamuris.js streamuris.bk

--- a/filechanges/boot/config/settings.ini
+++ b/filechanges/boot/config/settings.ini
@@ -259,13 +259,6 @@ port = 6680
 #Disable zeroconf
 zeroconf = ""
 
-# -------------
-# | Webclient |
-# -------------
-# Here you can change the default webclient
-# options: /opt/webclient /opt/moped
-static_dir = /opt/webclient
-
 [websettings]
 enabled = true
 musicbox = true

--- a/filechanges/etc/nginx/sites-available/default
+++ b/filechanges/etc/nginx/sites-available/default
@@ -1,0 +1,150 @@
+# You may add here your
+# server {
+#	...
+# }
+# statements for each of your virtual hosts to this file
+
+##
+# You should look at the following URL's in order to grasp a solid understanding
+# of Nginx configuration files in order to fully unleash the power of Nginx.
+# http://wiki.nginx.org/Pitfalls
+# http://wiki.nginx.org/QuickStart
+# http://wiki.nginx.org/Configuration
+#
+# Generally, you will want to move this file somewhere, and start with a clean
+# file but keep this around for reference. Or just disable in sites-enabled.
+#
+# Please see /usr/share/doc/nginx-doc/examples/ for more detailed examples.
+##
+
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    '' close;
+}
+
+server {
+	#listen   80; ## listen for ipv4; this line is default and implied
+	#listen   [::]:80 default_server ipv6only=on; ## listen for ipv6
+
+	root /usr/share/nginx/www;
+	index index.html index.htm;
+
+	# Make site accessible from http://localhost/
+	server_name localhost;
+
+	# Enable websocket proxying for mopidy
+	location /mopidy/ws {
+                proxy_pass http://localhost:6680;
+                proxy_http_version 1.1;
+                proxy_set_header Upgrade $http_upgrade;
+                proxy_set_header Connection $connection_upgrade;
+                proxy_read_timeout 604800;
+                proxy_send_timeout 604800;
+        }
+
+	# Redirect root folder to the Mopidy MusicBox Webclient (default)
+	# Change the URL in the 'rewrite' directive to specify another
+	# default web client
+	location = / {
+		rewrite ^ http://$host/musicbox_webclient/;
+        	proxy_pass http://localhost:6680/;
+                proxy_http_version 1.1;
+	}
+
+	# Redirect requests on port 80 to port 6680
+        location / {
+                proxy_pass http://localhost:6680/;
+                proxy_http_version 1.1;
+        }
+
+#	location / {
+#		# First attempt to serve request as file, then
+#		# as directory, then fall back to displaying a 404.
+#		try_files $uri $uri/ /index.html;
+#		# Uncomment to enable naxsi on this location
+#		# include /etc/nginx/naxsi.rules
+#	}
+
+	location /doc/ {
+		alias /usr/share/doc/;
+		autoindex on;
+		allow 127.0.0.1;
+#		allow ::1;
+		deny all;
+	}
+
+	# Only for nginx-naxsi used with nginx-naxsi-ui : process denied requests
+	#location /RequestDenied {
+	#	proxy_pass http://127.0.0.1:8080;    
+	#}
+
+	#error_page 404 /404.html;
+
+	# redirect server error pages to the static page /50x.html
+	#
+	#error_page 500 502 503 504 /50x.html;
+	#location = /50x.html {
+	#	root /usr/share/nginx/www;
+	#}
+
+	# pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+	#
+	#location ~ \.php$ {
+	#	fastcgi_split_path_info ^(.+\.php)(/.+)$;
+	#	# NOTE: You should have "cgi.fix_pathinfo = 0;" in php.ini
+	#
+	#	# With php5-cgi alone:
+	#	fastcgi_pass 127.0.0.1:9000;
+	#	# With php5-fpm:
+	#	fastcgi_pass unix:/var/run/php5-fpm.sock;
+	#	fastcgi_index index.php;
+	#	include fastcgi_params;
+	#}
+
+	# deny access to .htaccess files, if Apache's document root
+	# concurs with nginx's one
+	#
+	#location ~ /\.ht {
+	#	deny all;
+	#}
+}
+
+
+# another virtual host using mix of IP-, name-, and port-based configuration
+#
+#server {
+#	listen 8000;
+#	listen somename:8080;
+#	server_name somename alias another.alias;
+#	root html;
+#	index index.html index.htm;
+#
+#	location / {
+#		try_files $uri $uri/ =404;
+#	}
+#}
+
+
+# HTTPS server
+#
+#server {
+#	listen 443;
+#	server_name localhost;
+#
+#	root html;
+#	index index.html index.htm;
+#
+#	ssl on;
+#	ssl_certificate cert.pem;
+#	ssl_certificate_key cert.key;
+#
+#	ssl_session_timeout 5m;
+#
+#	ssl_protocols SSLv3 TLSv1;
+#	ssl_ciphers ALL:!ADH:!EXPORT56:RC4+RSA:+HIGH:+MEDIUM:+LOW:+SSLv3:+EXP;
+#	ssl_prefer_server_ciphers on;
+#
+#	location / {
+#		try_files $uri $uri/ =404;
+#	}
+#}

--- a/filechanges/etc/samba/smb.conf
+++ b/filechanges/etc/samba/smb.conf
@@ -86,7 +86,7 @@ follow symlinks = yes
     directory mask = 0777
 
 #[Webclient]
-#    path = /opt/defaultwebclient
+#    path = /opt/webclient
 #        writable = yes
 #        browseable = yes
 #        guest ok = yes

--- a/filechanges/opt/musicbox/startup.sh
+++ b/filechanges/opt/musicbox/startup.sh
@@ -120,9 +120,6 @@ then
     /etc/init.d/samba restart
 fi
 
-#redirect 6680 to 80
-iptables -t nat -A PREROUTING -p tcp --dport 80 -j REDIRECT --to-port 6680 > /dev/null 2>&1 || true
-
 # start SSH if enabled
 if [ "$INI__network__enable_ssh" == "1" ]
 then


### PR DESCRIPTION
See http://nginx.org for details.
- Map port 80 to 6680 to allow easy access using http://musicbox.local
- Specify the default Mopidy webclient to use (see 'rewrite' directive in default nginx configuration file) 
