### PR TITLE
Change read_ini.sh to use associative arrays.

### DIFF
--- a/Create Pi MusicBox.rst
+++ b/Create Pi MusicBox.rst
@@ -38,13 +38,13 @@ Next, issue this command to update the distribution. This is good because newer 
 
 Install all packages we need with this command:
 
-    sudo apt-get update && sudo apt-get --yes --no-install-suggests --no-install-recommends install logrotate alsa-utils wpasupplicant gstreamer0.10-alsa ifplugd gstreamer0.10-fluendo-mp3 gstreamer0.10-tools samba dos2unix avahi-utils alsa-base cifs-utils avahi-autoipd libnss-mdns ntpdate ca-certificates ncmpcpp rpi-update linux-wlan-ng alsa-firmware-loaders iw atmel-firmware firmware-atheros firmware-brcm80211 firmware-ipw2x00 firmware-iwlwifi firmware-libertas firmware-linux firmware-linux-nonfree firmware-ralink firmware-realtek zd1211-firmware linux-wlan-ng-firmware alsa-firmware-loaders iptables build-essential python-dev python-pip python-gst0.10 gstreamer0.10-plugins-good gstreamer0.10-plugins-bad gstreamer0.10-plugins-ugly gstreamer0.10-tools usbmount monit upmpdcli watchdog dropbear mpc dosfstools logrotate
+    sudo apt-get update && sudo apt-get --yes --no-install-suggests --no-install-recommends install logrotate alsa-utils wpasupplicant gstreamer0.10-alsa ifplugd gstreamer0.10-fluendo-mp3 gstreamer0.10-tools samba dos2unix avahi-utils alsa-base cifs-utils avahi-autoipd libnss-mdns ntpdate ca-certificates ncmpcpp rpi-update linux-wlan-ng alsa-firmware-loaders iw atmel-firmware firmware-atheros firmware-brcm80211 firmware-ipw2x00 firmware-iwlwifi firmware-libertas firmware-linux firmware-linux-nonfree firmware-ralink firmware-realtek zd1211-firmware linux-wlan-ng-firmware iptables build-essential python-dev python-pip python-gst0.10 gstreamer0.10-plugins-good gstreamer0.10-plugins-bad gstreamer0.10-plugins-ugly usbmount monit upmpdcli watchdog dropbear mpc dosfstools
 
 Depending on your configuration, you could leave out certain packages, e.g. the firmware files if you don't use a wireless dongle.
 
 Then install mopidy and the extensions we need:
 
-    sudo pip install -U mopidy mopidy-spotify mopidy-local-sqlite mopidy-local-whoosh mopidy-scrobbler mopidy-soundcloud mopidy-dirble mopidy-tunein mopidy-gmusic mopidy-subsonic mopidy-http-kuechenradio mopidy-moped mopidy-musicbox-webclient mopidy-websettings mopidy-internetarchive mopidy-podcast mopidy-podcast-itunes mopidy-podcast-gpodder.net mopidy-simplewebclient mopidy-somafm mopidy-spotify-tunigo mopidy-youtube
+    sudo pip install -U mopidy mopidy-spotify mopidy-local-sqlite mopidy-local-whoosh mopidy-scrobbler mopidy-soundcloud mopidy-dirble mopidy-tunein mopidy-gmusic mopidy-subsonic mopidy-mobile mopidy-moped mopidy-musicbox-webclient mopidy-websettings mopidy-internetarchive mopidy-podcast mopidy-podcast-itunes mopidy-podcast-gpodder.net Mopidy-Simple-Webclient mopidy-somafm mopidy-spotify-tunigo mopidy-youtube
 
 Google Music works a lot better if you use the development version of mopidy-gmusic:
 
@@ -102,6 +102,8 @@ Create a symlink from the package to the /opt/webclient and to /opt/defaultwebcl
 
     ln -fsn /usr/local/lib/python2.7/dist-packages/mopidy_musicbox_webclient/static /opt/webclient
 
+    ln -fsn /usr/local/lib/python2.7/dist-packages/mopidy_moped/static /opt/moped
+
     ln -fsn /opt/webclient /opt/defaultwebclient
 
 Remove the streamuris.js and point it to the file in /boot/config
@@ -120,7 +122,7 @@ Mopidy runs under the user mopidy. Add it.
 
     useradd -m mopidy
 
-    passwd mopidy
+    passwd -l mopidy
 
 Add the user to the group audio:
 
@@ -197,7 +199,7 @@ Update the kernel to make sure all optimizations of newer core-software:
 
 **USB Fix**
 
-It's tricky to get good sound out of the Pi. For USB Audio (sound cards, etc), it is essential to disable the so called FIQ_SPLIT. Why? It seems that audio at high bitrates interferes with the ethernet activity, which also runs over USB. Add these options to the cmdline.txt file on your SD Card.
+It's tricky to get good sound out of the Pi. For USB Audio (sound cards, etc), it is essential to disable the so called FIQ_SPLIT. Why? It seems that audio at high nitrates interferes with the ethernet activity, which also runs over USB. Add these options to the cmdline.txt file on your SD Card.
 
     dwc_otg.fiq_fix_enable=1 dwc_otg.fiq_split_enable=0
 

--- a/Create Pi MusicBox.rst
+++ b/Create Pi MusicBox.rst
@@ -197,7 +197,7 @@ Update the kernel to make sure all optimizations of newer core-software:
 
 **USB Fix**
 
-It's tricky to get good sound out of the Pi. For USB Audio (sound cards, etc), it is essential to disable the so called FIQ_SPLIT. Why? It seems that audio at high nitrates interferes with the ethernet activity, which also runs over USB. Add these options to the cmdline.txt file on your SD Card.
+It's tricky to get good sound out of the Pi. For USB Audio (sound cards, etc), it is essential to disable the so called FIQ_SPLIT. Why? It seems that audio at high bitrates interferes with the ethernet activity, which also runs over USB. Add these options to the cmdline.txt file on your SD Card.
 
     dwc_otg.fiq_fix_enable=1 dwc_otg.fiq_split_enable=0
 

--- a/authors.txt
+++ b/authors.txt
@@ -6,6 +6,7 @@ Pi MusicBox was created by Wouter van Wijk and includes contributions from the f
 - Remco Brink <remco@rc6.org>
 - Amit Kotlovski <amitbk@gmail.com>
 - John Cass <john.cass77@gmail.com>
+- Bastien Nocera <@hadess>
 
 Pi MusicBox makes use of the following great projects:
 - Raspbian (based on Debian Linux): http://raspbian.org

--- a/changes.rst
+++ b/changes.rst
@@ -1,6 +1,22 @@
 **Pi MusicBox Changelog**
 -------------------------
 
+v0.6 (6 april 2015)
+----------------------------------------
+- Raspberry Pi 2 compatability (using updated kernel)
+- Enhanced support for local/networked files
+- New version of the MusicBox Webinterface (2.0)
+- Stability fixes
+- Many other bugfixes
+- Compatible with Mopidy v0.19.5
+
+v0.6.0 RC (29 March 2015)
+----------------------------------------
+- Added support for HiFiBerry AMP
+- Fixed USB soundcard detection
+- Removed some entries for extensions in settings.ini where using defaults.
+- Compatible with Mopidy v0.19.5
+
 v0.5.4 (25 February 2015)
 ----------------------------------------
 - Initial Raspberry Pi 2 compatability.

--- a/create_musicbox.sh
+++ b/create_musicbox.sh
@@ -22,10 +22,10 @@ apt-get dist-upgrade -y
 ntpdate -u ntp.ubuntu.com
 
 #Then install all packages we need with this command:
-sudo apt-get update && sudo apt-get --yes --no-install-suggests --no-install-recommends install logrotate alsa-utils wpasupplicant gstreamer0.10-alsa ifplugd gstreamer0.10-fluendo-mp3 gstreamer0.10-tools samba dos2unix avahi-utils alsa-base cifs-utils avahi-autoipd libnss-mdns ntpdate ca-certificates ncmpcpp rpi-update linux-wlan-ng alsa-firmware-loaders iw atmel-firmware firmware-atheros firmware-brcm80211 firmware-ipw2x00 firmware-iwlwifi firmware-libertas firmware-linux firmware-linux-nonfree firmware-ralink firmware-realtek zd1211-firmware linux-wlan-ng-firmware alsa-firmware-loaders iptables build-essential python-dev python-pip python-gst0.10 gstreamer0.10-plugins-good gstreamer0.10-plugins-bad gstreamer0.10-plugins-ugly gstreamer0.10-tools usbmount monit upmpdcli watchdog dropbear mpc dosfstools logrotate
+sudo apt-get update && sudo apt-get --yes --no-install-suggests --no-install-recommends install logrotate alsa-utils wpasupplicant gstreamer0.10-alsa ifplugd gstreamer0.10-fluendo-mp3 gstreamer0.10-tools samba dos2unix avahi-utils alsa-base cifs-utils avahi-autoipd libnss-mdns ntpdate ca-certificates ncmpcpp rpi-update linux-wlan-ng alsa-firmware-loaders iw atmel-firmware firmware-atheros firmware-brcm80211 firmware-ipw2x00 firmware-iwlwifi firmware-libertas firmware-linux firmware-linux-nonfree firmware-ralink firmware-realtek zd1211-firmware linux-wlan-ng-firmware iptables build-essential python-dev python-pip python-gst0.10 gstreamer0.10-plugins-good gstreamer0.10-plugins-bad gstreamer0.10-plugins-ugly usbmount monit upmpdcli watchdog dropbear mpc dosfstools
 
 #mopidy from pip
-sudo pip install -U mopidy mopidy-spotify mopidy-local-sqlite mopidy-local-whoosh mopidy-scrobbler mopidy-soundcloud mopidy-dirble mopidy-tunein mopidy-gmusic mopidy-subsonic mopidy-http-kuechenradio mopidy-moped mopidy-musicbox-webclient mopidy-websettings mopidy-internetarchive mopidy-podcast mopidy-podcast-itunes mopidy-podcast-gpodder.net mopidy-simplewebclient mopidy-somafm mopidy-spotify-tunigo mopidy-youtube
+sudo pip install -U mopidy mopidy-spotify mopidy-local-sqlite mopidy-local-whoosh mopidy-scrobbler mopidy-soundcloud mopidy-dirble mopidy-tunein mopidy-gmusic mopidy-subsonic mopidy-mobile mopidy-moped mopidy-musicbox-webclient mopidy-websettings mopidy-internetarchive mopidy-podcast mopidy-podcast-itunes mopidy-podcast-gpodder.net Mopidy-Simple-Webclient mopidy-somafm mopidy-spotify-tunigo mopidy-youtube
 
 #Google Music works a lot better if you use the development version of mopidy-gmusic:
 sudo pip install https://github.com/hechtus/mopidy-gmusic/archive/develop.zip
@@ -59,6 +59,7 @@ chmod 600 /etc/firewall/musicbox_iptables
 
 #Next, create a symlink from the package to the /opt/defaultwebclient.
 ln -fsn /usr/local/lib/python2.7/dist-packages/mopidy_musicbox_webclient/static /opt/webclient
+ln -fsn /usr/local/lib/python2.7/dist-packages/mopidy_moped/static /opt/moped
 ln -fsn /opt/webclient /opt/defaultwebclient
 
 #Remove the streamuris.js and point it to the file in /boot/config
@@ -71,7 +72,7 @@ chmod u+s /sbin/shutdown
 #**Add the mopidy user**
 #Mopidy runs under the user mopidy. Add it.
 useradd -m mopidy
-passwd mopidy
+passwd -l mopidy
 
 #Add the user to the group audio:
 usermod -a -G audio mopidy

--- a/create_musicbox.sh
+++ b/create_musicbox.sh
@@ -108,7 +108,7 @@ ln -fsn /boot/config/settings.ini /var/lib/mopidy/.config/mopidy/mopidy.conf
 #**USB Fix**
 #It's tricky to get good sound out of the Pi. For USB Audio (sound cards, etc),
 # it is essential to disable the so called FIQ_SPLIT. Why? It seems that audio
-# at high nitrates interferes with the ethernet activity, which also runs over USB.
+# at high bitrates interferes with the ethernet activity, which also runs over USB.
 # These options are added at the beginning of the cmdline.txt file in /boot
 sed -i '1s/^/dwc_otg.fiq_fix_enable=1 dwc_otg.fiq_split_enable=0 smsc95xx.turbo_mode=N /' /boot/cmdline.txt
 

--- a/filechanges/boot/config/settings.ini
+++ b/filechanges/boot/config/settings.ini
@@ -285,11 +285,44 @@ playlists_dir = /var/lib/mopidy/playlists
 data_dir = /var/lib/mopidy/localdata
 #This sets the method of indexing local files
 #You can set it to json or whoosh. Whoosh might be better with large collections, JSON is a bit more mature.
-# TODO: You cannot add settings for [local-sqlite]
-# because it breaks the startup script (won't read dashes in section names
 library = sqlite
 
 scan_timeout = 1000
-scan_flush_threshold = 1000
+scan_flush_threshold = 100
 excluded_file_extensions = .html, .jpeg, .jpg, .log, .nfo, .png, .txt, .mkv, .avi, .divx, .qt, .wmv, .htm, .zip, .rar, .gz, .pdf, .exe, .ini, .mid, .db, .m3u, .sfv, .midi
 
+[local-sqlite]
+enabled = true
+
+# NOTE: Handling of complex parameters (e.g. that contain spaces and do not contain '=') are not
+#       currently handled properly by read_ini.sh. Commented out this section in order to revert
+#       to using default values instead.
+#       (see https://github.com/rudimeier/bash_ini_parser/issues/2 for details
+# top-level directories for browsing, as <name> <uri>
+#directories =
+#    Albums                  local:directory?type=album
+#    Artists                 local:directory?type=artist
+#    Composers               local:directory?type=artist&role=composer
+#    Folders                 local:directory:
+#    Genres                  local:directory?type=genre
+#    Performers              local:directory?type=artist&role=performer
+#    Release Years           local:directory?type=date&format=%25Y
+#    Tracks                  local:directory?type=track
+#    Last Week's Updates     local:directory?max-age=604800
+#    Last Month's Updates    local:directory?max-age=2592000
+
+# database connection timeout in seconds
+timeout = 10
+
+# whether to use an album's musicbrainz_id for generating its URI
+use_album_mbid_uri = true
+
+# whether to use an artist's musicbrainz_id for generating its URI;
+# disabled by default, since some taggers do not handle this well for
+# multi-artist tracks [https://github.com/sampsyo/beets/issues/907]
+use_artist_mbid_uri = false
+
+# override search limit provided by Mopidy core; set to -1 (no limit)
+# to emulate current behavior of json library
+# [https://github.com/mopidy/mopidy/issues/917]
+search_limit = -1

--- a/filechanges/boot/config/settings.ini
+++ b/filechanges/boot/config/settings.ini
@@ -250,7 +250,6 @@ control =
 
 [stream]
 enabled = true
-protocols = http, https, mms, file, rtmp, rtmps, rtsp, udp, mmsh
 
 [http]
 enabled = true
@@ -265,6 +264,10 @@ zeroconf = ""
 # Here you can change the default webclient
 # options: /opt/webclient /opt/moped
 static_dir = /opt/webclient
+
+[musicbox_webclient]
+enabled = true
+musicbox = true
 
 [websettings]
 enabled = true

--- a/filechanges/boot/config/settings.ini
+++ b/filechanges/boot/config/settings.ini
@@ -297,22 +297,18 @@ excluded_file_extensions = .html, .jpeg, .jpg, .log, .nfo, .png, .txt, .mkv, .av
 [local-sqlite]
 enabled = true
 
-# NOTE: Handling of complex parameters (e.g. that contain spaces and do not contain '=') are not
-#       currently handled properly by read_ini.sh. Commented out this section in order to revert
-#       to using default values instead.
-#       (see https://github.com/rudimeier/bash_ini_parser/issues/2 for details
 # top-level directories for browsing, as <name> <uri>
-#directories =
-#    Albums                  local:directory?type=album
-#    Artists                 local:directory?type=artist
-#    Composers               local:directory?type=artist&role=composer
-#    Folders                 local:directory:
-#    Genres                  local:directory?type=genre
-#    Performers              local:directory?type=artist&role=performer
-#    Release Years           local:directory?type=date&format=%25Y
-#    Tracks                  local:directory?type=track
-#    Last Week's Updates     local:directory?max-age=604800
-#    Last Month's Updates    local:directory?max-age=2592000
+directories =
+    Albums                  local:directory?type=album
+    Artists                 local:directory?type=artist
+    Composers               local:directory?type=artist&role=composer
+    Folders                 local:directory:
+    Genres                  local:directory?type=genre
+    Performers              local:directory?type=artist&role=performer
+    Release Years           local:directory?type=date&format=%25Y
+    Tracks                  local:directory?type=track
+    Last Week's Updates     local:directory?max-age=604800
+    Last Month's Updates    local:directory?max-age=2592000
 
 # database connection timeout in seconds
 timeout = 10

--- a/filechanges/opt/musicbox/read_ini.sh
+++ b/filechanges/opt/musicbox/read_ini.sh
@@ -281,5 +281,3 @@ function read_ini()
 
 	cleanup_bash
 }
-
-

--- a/filechanges/opt/musicbox/read_ini.sh
+++ b/filechanges/opt/musicbox/read_ini.sh
@@ -11,281 +11,275 @@
 #
 
 
-#function read_config_file()
-#{
 
-##convert windows ini to unix
-#dos2unix -n $1 /tmp/settings.ini > /dev/null 2>&1 || true
-
-## ini vars to mopidy settings
-#read_ini /tmp/settings.ini MusicBox
-
-#rm /tmp/settings.ini > /dev/null 2>&1 || true
-
-#}
 
 function read_ini()
 {
-    # Be strict with the prefix, since it's going to be run through eval
-    function check_prefix()
-    {
-	if ! [[ "${VARNAME_PREFIX}" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]] ;then
-	    echo "read_ini: invalid prefix '${VARNAME_PREFIX}'" >&2
-	    return 1
-	fi
-    }
-    
-    function check_ini_file()
-    {
-	if [ ! -r "$INI_FILE" ] ;then
-	    echo "read_ini: '${INI_FILE}' doesn't exist or not" \
-		"readable" >&2
-	    return 1
-	fi
-    }
-    
-    # enable some optional shell behavior (shopt)
-    function pollute_bash()
-    {
-	if ! shopt -q extglob ;then
-	    SWITCH_SHOPT="${SWITCH_SHOPT} extglob"
-	fi
-	if ! shopt -q nocasematch ;then
-	    SWITCH_SHOPT="${SWITCH_SHOPT} nocasematch"
-	fi
-	shopt -q -s ${SWITCH_SHOPT}
-    }
-    
-    # unset all local functions and restore shopt settings before returning
-    # from read_ini()
-    function cleanup_bash()
-    {
-	shopt -q -u ${SWITCH_SHOPT}
-	unset -f check_prefix check_ini_file pollute_bash cleanup_bash
-    }
-    
-    local INI_FILE=""
-    local INI_SECTION=""
-
-    # {{{ START Deal with command line args
-
-    # Set defaults
-    local BOOLEANS=1
-    local VARNAME_PREFIX=INI
-    local CLEAN_ENV=0
-
-    # {{{ START Options
-
-    # Available options:
-    #	--boolean		Whether to recognise special boolean values: ie for 'yes', 'true'
-    #					and 'on' return 1; for 'no', 'false' and 'off' return 0. Quoted
-    #					values will be left as strings
-    #					Default: on
-    #
-    #	--prefix=STRING	String to begin all returned variables with (followed by '__').
-    #					Default: INI
-    #
-    #	First non-option arg is filename, second is section name
-
-    while [ $# -gt 0 ]
-    do
-
-	case $1 in
-
-	    --clean | -c )
-		CLEAN_ENV=1
-	    ;;
-
-	    --booleans | -b )
-		shift
-		BOOLEANS=$1
-	    ;;
-
-	    --prefix | -p )
-		shift
-		VARNAME_PREFIX=$1
-	    ;;
-
-	    * )
-		if [ -z "$INI_FILE" ]
-		then
-		    INI_FILE=$1
-		else
-		    if [ -z "$INI_SECTION" ]
-		    then
-			INI_SECTION=$1
-		    fi
+	# Be strict with the prefix, since it's going to be run through eval
+	function check_prefix()
+	{
+		if ! [[ "${VARNAME_PREFIX}" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]] ;then
+			echo "read_ini: invalid prefix '${VARNAME_PREFIX}'" >&2
+			return 1
 		fi
-	    ;;
+	}
+	
+	function check_ini_file()
+	{
+		if [ ! -r "$INI_FILE" ] ;then
+			echo "read_ini: '${INI_FILE}' doesn't exist or not" \
+				"readable" >&2
+			return 1
+		fi
+	}
+	
+	# enable some optional shell behavior (shopt)
+	function pollute_bash()
+	{
+		if ! shopt -q extglob ;then
+			SWITCH_SHOPT="${SWITCH_SHOPT} extglob"
+		fi
+		if ! shopt -q nocasematch ;then
+			SWITCH_SHOPT="${SWITCH_SHOPT} nocasematch"
+		fi
+		shopt -q -s ${SWITCH_SHOPT}
+	}
+	
+	# unset all local functions and restore shopt settings before returning
+	# from read_ini()
+	function cleanup_bash()
+	{
+		shopt -q -u ${SWITCH_SHOPT}
+		unset -f check_prefix check_ini_file pollute_bash cleanup_bash
+	}
+	
+	local INI_FILE=""
+	local INI_SECTION=""
 
-	esac
+	# {{{ START Deal with command line args
 
-	shift
-    done
+	# Set defaults
+	local BOOLEANS=1
+	local VARNAME_PREFIX=INI
+	local CLEAN_ENV=0
 
-    if [ -z "$INI_FILE" ] && [ "${CLEAN_ENV}" = 0 ] ;then
-	echo -e "Usage: read_ini [-c] [-b 0| -b 1]] [-p PREFIX] FILE"\
-	    "[SECTION]\n  or   read_ini -c [-p PREFIX]" >&2
-	cleanup_bash
-	return 1
-    fi
+	# {{{ START Options
 
-    if ! check_prefix ;then
-	cleanup_bash
-	return 1
-    fi
+	# Available options:
+	#	--boolean		Whether to recognise special boolean values: ie for 'yes', 'true'
+	#					and 'on' return 1; for 'no', 'false' and 'off' return 0. Quoted
+	#					values will be left as strings
+	#					Default: on
+	#
+	#	--prefix=STRING	String to begin all returned variables with (followed by '__').
+	#					Default: INI
+	#
+	#	First non-option arg is filename, second is section name
 
-    local INI_ALL_VARNAME="${VARNAME_PREFIX}__ALL_VARS"
-    local INI_ALL_SECTION="${VARNAME_PREFIX}__ALL_SECTIONS"
-    local INI_NUMSECTIONS_VARNAME="${VARNAME_PREFIX}__NUMSECTIONS"
-    if [ "${CLEAN_ENV}" = 1 ] ;then
-	eval unset "\$${INI_ALL_VARNAME}"
-    fi
-    unset ${INI_ALL_VARNAME}
-    unset ${INI_ALL_SECTION}
-    unset ${INI_NUMSECTIONS_VARNAME}
+	while [ $# -gt 0 ]
+	do
 
-    if [ -z "$INI_FILE" ] ;then
-	cleanup_bash
-	return 0
-    fi
-    
-    if ! check_ini_file ;then
-	cleanup_bash
-	return 1
-    fi
+		case $1 in
 
-    # Sanitise BOOLEANS - interpret "0" as 0, anything else as 1
-    if [ "$BOOLEANS" != "0" ]
-    then
-	BOOLEANS=1
-    fi
+			--clean | -c )
+				CLEAN_ENV=1
+			;;
+
+			--booleans | -b )
+				shift
+				BOOLEANS=$1
+			;;
+
+			--prefix | -p )
+				shift
+				VARNAME_PREFIX=$1
+			;;
+
+			* )
+				if [ -z "$INI_FILE" ]
+				then
+					INI_FILE=$1
+				else
+					if [ -z "$INI_SECTION" ]
+					then
+						INI_SECTION=$1
+					fi
+				fi
+			;;
+
+		esac
+
+		shift
+	done
+
+	if [ -z "$INI_FILE" ] && [ "${CLEAN_ENV}" = 0 ] ;then
+		echo -e "Usage: read_ini [-c] [-b 0| -b 1]] [-p PREFIX] FILE"\
+			"[SECTION]\n  or   read_ini -c [-p PREFIX]" >&2
+		cleanup_bash
+		return 1
+	fi
+
+	if ! check_prefix ;then
+		cleanup_bash
+		return 1
+	fi
+
+	local INI_NUMSECTIONS_VARNAME="${VARNAME_PREFIX}__NUMSECTIONS"
+	if [ "${CLEAN_ENV}" = 1 ] ;then
+		# TODO How to clear the whole array without unset it
+		for i in "${!INI[@]}" ;do
+			unset ${VARNAME_PREFIX}['$i']
+		done
+	fi
+
+	# TODO How to declare -A ${VARNAME_PREFIX} non local? Or we have to
+	# check for a global declared one
+	unset ${INI_NUMSECTIONS_VARNAME}
+
+	if [ -z "$INI_FILE" ] ;then
+		cleanup_bash
+		return 0
+	fi
+	
+	if ! check_ini_file ;then
+		cleanup_bash
+		return 1
+	fi
+
+	# Sanitise BOOLEANS - interpret "0" as 0, anything else as 1
+	if [ "$BOOLEANS" != "0" ]
+	then
+		BOOLEANS=1
+	fi
 
 
-    # }}} END Options
+	# }}} END Options
 
-    # }}} END Deal with command line args
+	# }}} END Deal with command line args
 
-    local LINE_NUM=0
-    local SECTIONS_NUM=0
-    local SECTION=""
-    
-    # IFS is used in "read" and we want to switch it within the loop
-    local IFS=$' \t\n'
-    local IFS_OLD="${IFS}"
-    
-    # we need some optional shell behavior (shopt) but want to restore
-    # current settings before returning
-    local SWITCH_SHOPT=""
-    pollute_bash
-    
-    while read -r line || [ -n "$line" ]
-    do
+	local LINE_NUM=0
+	local SECTIONS_NUM=0
+	local SECTION=""
+	
+	# IFS is used in "read" and we want to switch it within the loop
+	local IFS=$' \t\n'
+	local IFS_OLD="${IFS}"
+	
+	# we need some optional shell behavior (shopt) but want to restore
+	# current settings before returning
+	local SWITCH_SHOPT=""
+	pollute_bash
+	
+	while read -r line || [ -n "$line" ]
+	do
 #echo line = "$line"
 
-	((LINE_NUM++))
+		((LINE_NUM++))
 
-	# Skip blank lines and comments
-	if [ -z "$line" -o "${line:0:1}" = ";" -o "${line:0:1}" = "#" ]
-	then
-	    continue
-	fi
+		# Skip blank lines and comments
+		if [ -z "$line" -o "${line:0:1}" = ";" -o "${line:0:1}" = "#" ]
+		then
+			continue
+		fi
 
-	# Section marker?
-	if [[ "${line}" =~ ^\[[a-zA-Z0-9_]{1,}\]$ ]]
-	then
+		# Section marker?
+		if [[ "${line}" =~ ^\[.*\]$ ]]
+		then
+			# Set SECTION var to name of section (strip [ and ] from section marker)
+			SECTION="${line#[}"
+			SECTION="${SECTION%]}"
+			read SECTION <<<"${SECTION}"
+			if ! [[ "${line}" =~ ^[[:print:]]+$  ]] ;then
+				echo "Error: Invalid section:" >&2
+				echo " ${LINE_NUM}: '$line'" >&2
+				cleanup_bash
+				return 1
+			fi
+			((SECTIONS_NUM++))
 
-	    # Set SECTION var to name of section (strip [ and ] from section marker)
-	    SECTION="${line#[}"
-	    SECTION="${SECTION%]}"
-	    eval "${INI_ALL_SECTION}=\"\${${INI_ALL_SECTION}# } $SECTION\""
-	    ((SECTIONS_NUM++))
+			continue
+		fi
 
-	    continue
-	fi
+		# Are we getting only a specific section? And are we currently in it?
+		if [ ! -z "$INI_SECTION" ]
+		then
+			if [ "$SECTION" != "$INI_SECTION" ]
+			then
+				continue
+			fi
+		fi
 
-	# Are we getting only a specific section? And are we currently in it?
-	if [ ! -z "$INI_SECTION" ]
-	then
-	    if [ "$SECTION" != "$INI_SECTION" ]
-	    then
-		continue
-	    fi
-	fi
-
-	# Valid var/value line? (check for variable name and then '=')
-	if ! [[ "${line}" =~ ^[a-zA-Z0-9._]{1,}[[:space:]]*= ]]
-	then
-	    echo "Error: Invalid line:" >&2
-	    echo " ${LINE_NUM}: $line" >&2
-	    cleanup_bash
-	    return 1
-	fi
+		# Valid var/value line? (check for variable name and then '=')
+		if ! [[ "${line}" =~ ^[[:print:]]+[[:space:]]*= ]]
+		then
+			echo "Error: Invalid line:" >&2
+			echo " ${LINE_NUM}: '$line'" >&2
+			cleanup_bash
+			return 1
+		fi
 
 
-	# split line at "=" sign
-	IFS="="
-	read -r VAR VAL <<< "${line}"
-	IFS="${IFS_OLD}"
+		# split line at "=" sign
+		IFS="="
+		read -r VAR VAL <<< "${line}"
+		IFS="${IFS_OLD}"
+		
+		# delete spaces around the equal sign (using extglob)
+		VAR="${VAR%%+([[:space:]])}"
+		VAL="${VAL##+([[:space:]])}"
+		VAR=$(echo $VAR)
+
+
+		# Construct variable name:
+		# ${VARNAME_PREFIX}__$SECTION__$VAR
+		# Or if not in a section:
+		# ${VARNAME_PREFIX}__$VAR
+		# In both cases, full stops ('.') are replaced with underscores ('_')
+		if [ -z "$SECTION" ]
+		then
+			VARNAME=${VAR//./_}
+		else
+			VARNAME=${SECTION}__${VAR//./_}
+		fi
+
+		if [[ "${VAL}" =~ ^\".*\"$  ]]
+		then
+			# remove existing double quotes
+			VAL="${VAL##\"}"
+			VAL="${VAL%%\"}"
+		elif [[ "${VAL}" =~ ^\'.*\'$  ]]
+		then
+			# remove existing single quotes
+			VAL="${VAL##\'}"
+			VAL="${VAL%%\'}"
+		elif [ "$BOOLEANS" = 1 ]
+		then
+			# Value is not enclosed in quotes
+			# Booleans processing is switched on, check for special boolean
+			# values and convert
+
+			# here we compare case insensitive because
+			# "shopt nocasematch"
+			case "$VAL" in
+				yes | true | on )
+					VAL=1
+				;;
+				no | false | off )
+					VAL=0
+				;;
+			esac
+		fi
+		
+#  		echo "pair: '${VARNAME}' = '${VAL}'"
+		eval ${VARNAME_PREFIX}$'[${VARNAME}]=${VAL}'
+# 		eval $'echo "array: \'${VARNAME}\' = \'${'${VARNAME_PREFIX}$'[${VARNAME}]}\'"'
+
+	done  <"${INI_FILE}"
 	
-	# delete spaces around the equal sign (using extglob)
-	VAR="${VAR%%+([[:space:]])}"
-	VAL="${VAL##+([[:space:]])}"
-	VAR=$(echo $VAR)
+	# return also the number of parsed sections
+	eval "$INI_NUMSECTIONS_VARNAME=$SECTIONS_NUM"
 
-
-	# Construct variable name:
-	# ${VARNAME_PREFIX}__$SECTION__$VAR
-	# Or if not in a section:
-	# ${VARNAME_PREFIX}__$VAR
-	# In both cases, full stops ('.') are replaced with underscores ('_')
-	if [ -z "$SECTION" ]
-	then
-	    VARNAME=${VARNAME_PREFIX}__${VAR//./_}
-	else
-	    VARNAME=${VARNAME_PREFIX}__${SECTION}__${VAR//./_}
-	fi
-	eval "${INI_ALL_VARNAME}=\"\${${INI_ALL_VARNAME}# } ${VARNAME}\""
-
-	if [[ "${VAL}" =~ ^\".*\"$  ]]
-	then
-	    # remove existing double quotes
-	    VAL="${VAL##\"}"
-	    VAL="${VAL%%\"}"
-	elif [[ "${VAL}" =~ ^\'.*\'$  ]]
-	then
-	    # remove existing single quotes
-	    VAL="${VAL##\'}"
-	    VAL="${VAL%%\'}"
-	elif [ "$BOOLEANS" = 1 ]
-	then
-	    # Value is not enclosed in quotes
-	    # Booleans processing is switched on, check for special boolean
-	    # values and convert
-
-	    # here we compare case insensitive because
-	    # "shopt nocasematch"
-	    case "$VAL" in
-		yes | true | on )
-		    VAL=1
-		;;
-		no | false | off )
-		    VAL=0
-		;;
-	    esac
-	fi
-	
-
-	# enclose the value in single quotes and escape any
-	# single quotes and backslashes that may be in the value
-	VAL="${VAL//\\/\\\\}"
-	VAL="\$'${VAL//\'/\'}'"
-
-	eval "$VARNAME=$VAL"
-    done  <"${INI_FILE}"
-    
-    # return also the number of parsed sections
-    eval "$INI_NUMSECTIONS_VARNAME=$SECTIONS_NUM"
-
-    cleanup_bash
+	cleanup_bash
 }
+
+

--- a/filechanges/opt/musicbox/read_ini.sh
+++ b/filechanges/opt/musicbox/read_ini.sh
@@ -117,8 +117,7 @@ function read_ini()
 			;;
 
 			--allow_no_value | -nv )
-				shift
-				NV=$1
+				NV=1
 			;;
 
 			--prefix | -p )
@@ -144,7 +143,7 @@ function read_ini()
 	done
 
 	if [ -z "$INI_FILE" ] && [ "${CLEAN_ENV}" = 0 ] ;then
-		echo -e "Usage: read_ini [-c] [-b 0| -b 1]] [-p PREFIX] FILE"\
+		echo -e "Usage: read_ini [-c] [-b 0| -b 1] [-nv] [-p PREFIX] FILE"\
 			"[SECTION]\n  or   read_ini -c [-p PREFIX]" >&2
 		cleanup_bash
 		return 1

--- a/filechanges/opt/musicbox/setsound.sh
+++ b/filechanges/opt/musicbox/setsound.sh
@@ -84,7 +84,7 @@ then
     declare -A INI
 
     # ini vars to mopidy settings
-    read_ini /tmp/settings.ini
+    read_ini -nv /tmp/settings.ini
 
     rm /tmp/settings.ini > /dev/null 2>&1 || true
 fi

--- a/filechanges/opt/musicbox/setsound.sh
+++ b/filechanges/opt/musicbox/setsound.sh
@@ -79,6 +79,10 @@ then
     # Convert windows ini to unix
     dos2unix -n $CONFIG_FILE /tmp/settings.ini > /dev/null 2>&1 || true
 
+    #declare $INI before reading ini https://github.com/rudimeier/bash_ini_parser/issues/2
+    unset INI
+    declare -A INI
+
     # ini vars to mopidy settings
     read_ini /tmp/settings.ini
 
@@ -88,7 +92,7 @@ fi
 # If output not defined, it will automatically detect USB / HDMI / Analog in given order
 # It is at this moment not possible to detect whether an i2s device is connected hence
 # i2s is only selected if explicitly given as output in the config file
-OUTPUT=$(echo $INI__musicbox__output | tr "[:upper:]" "[:lower:]")
+OUTPUT=$(echo ${INI["musicbox__output"]} | tr "[:upper:]" "[:lower:]")
 CARD=
 
 if [[ -z "$OUTPUT" ]]
@@ -171,7 +175,7 @@ fi
 
 log_progress_msg "Line out set to $OUTPUT card $CARD"
 
-if [ "$OUTPUT" == "usb" -a "$INI__musicbox__downsample_usb" == "1" ]
+if [ "$OUTPUT" == "usb" -a "${INI["musicbox__downsample_usb"]}" == "1" ]
 # resamples to 44K because of problems with some usb-dacs on 48k (probably related to usb drawbacks of Pi)
 # and extra buffer for usb
 #if [ "$OUTPUT" == "usb" ]

--- a/filechanges/opt/musicbox/startup.sh
+++ b/filechanges/opt/musicbox/startup.sh
@@ -39,7 +39,7 @@ INI_READ=true
 
 REBOOT=0
 
-if [ "$INI__musicbox__resize_once" == "1" ]
+if [ "${INI["musicbox__resize_once"]}" == "1" ]
 then
     #set resize_once=false in ini file
     sed -i -e "/^\[musicbox\]/,/^\[.*\]/ s|^\(resize_once[ \t]*=[ \t]*\).*$|\1false\r|" $CONFIG_FILE
@@ -51,7 +51,7 @@ fi
 #get name of device and trim
 HOSTNM=`cat /etc/hostname | tr -cd "[:alnum:]"`
 #get name in ini and trim
-CLEAN_NAME=$(echo $INI__network__name | tr -cd "[:alnum:]")
+CLEAN_NAME=$(echo ${INI["network__name"]} | tr -cd "[:alnum:]")
 #max 9 characters (max netbios length = 15, + '.local')
 CLEAN_NAME=$(echo $CLEAN_NAME | cut -c 1-9)
 
@@ -78,10 +78,10 @@ fi
 log_progress_msg "MusicBox name is $CLEAN_NAME" "$NAME"
 
 # do the change password stuff
-if [ "$INI__musicbox__root_password" != "" ]
+if [ "${INI["musicbox__root_password"]}" != "" ]
 then
     log_progress_msg "Setting root user Password" "$NAME"
-    echo "root:$INI__musicbox__root_password" | chpasswd
+    echo "root:${INI["musicbox__root_password"]}" | chpasswd
     #remove password
     sed -i -e "/^\[musicbox\]/,/^\[.*\]/ s|^\(root_password[ \t]*=[ \t]*\).*$|\1\r|" $CONFIG_FILE
 fi
@@ -89,15 +89,15 @@ fi
 #allow shutdown for all users
 chmod u+s /sbin/shutdown
 
-if [ "$INI__network__wifi_network" != "" ]
+if [ "${INI["network__wifi_network"]}" != "" ]
 then
     #put wifi settings for wpa roaming
 cat >/etc/wpa.conf <<EOF
     ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev
     update_config=1
     network={
-        ssid="$INI__network__wifi_network"
-        psk="$INI__network__wifi_password"
+        ssid="${INI["network__wifi_network"]}"
+        psk="${INI["network__wifi_password"]}"
         scan_ssid=1
     }
 EOF
@@ -112,10 +112,10 @@ fi
 #include code from setsound script
 . /opt/musicbox/setsound.sh
 
-if [ "$INI__network__workgroup" != "" ]
+if [ "${INI["network__workgroup"]}" != "" ]
 then
     #change smb.conf workgroup value
-    sed -i "s/workgroup = .*$/workgroup = $INI__network__workgroup/ig" /etc/samba/smb.conf
+    sed -i "s/workgroup = .*$/workgroup = ${INI["network__workgroup/ig"]}" /etc/samba/smb.conf
     #restart samba
     /etc/init.d/samba restart
 fi
@@ -124,7 +124,7 @@ fi
 iptables -t nat -A PREROUTING -p tcp --dport 80 -j REDIRECT --to-port 6680 > /dev/null 2>&1 || true
 
 # start SSH if enabled
-if [ "$INI__network__enable_ssh" == "1" ]
+if [ "${INI["network__enable_ssh"]}" == "1" ]
 then
     #create private keys for dropbear if they don't exist
     if [ ! -f "/etc/dropbear/dropbear_dss_host_key" ]
@@ -147,7 +147,7 @@ else
 fi
 
 # start upnp if enabled
-if [ "$INI__musicbox__enable_upnp" == "1" ]
+if [ "${INI["musicbox__enable_upnp"]}" == "1" ]
 then
     /etc/init.d/upmpdcli start
     ln -s /etc/monit/monitrc.d/upmpdcli /etc/monit/conf.d/upmpdcli > /dev/null 2>&1 || true
@@ -156,7 +156,7 @@ else
 fi
 
 # start shairport if enabled
-if [ "$INI__musicbox__enable_shairport" == "1" ]
+if [ "${INI["musicbox__enable_shairport"]}" == "1" ]
 then
     /etc/init.d/shairport-sync start
     ln -s /etc/monit/monitrc.d/shairport /etc/monit/conf.d/shairport > /dev/null 2>&1 || true
@@ -168,7 +168,7 @@ service monit start
 
 #check networking, sleep for a while
 MYIP=$(hostname -I)
-while [ "$MYIP" == "" -a "$INI__network__wait_for_network" != "0" ]
+while [ "$MYIP" == "" -a "${INI["network__wait_for_network"]}" != "0" ]
 do
     echo "Waiting for network..."
     echo
@@ -181,24 +181,24 @@ done
 ntpdate ntp.ubuntu.com > /dev/null 2>&1 || true
 
 #mount windows share
-if [ "$INI__network__mount_address" != "" ]
+if [ "${INI["network__mount_address"]}" != "" ]
 then
     #mount samba share, readonly
     log_progress_msg "Mounting Windows Network drive..." "$NAME"
-    mount -t cifs -o sec=ntlm,ro,user=$INI__network__mount_user,password=$INI__network__mount_password $INI__network__mount_address /music/Network/
-#    mount -t cifs -o sec=ntlm,ro,rsize=2048,wsize=4096,cache=strict,user=$INI__network__mount_user,password=$INI__network__mount_password $INI__network__mount_address /music/Network/
+    mount -t cifs -o sec=ntlm,ro,user=${INI["network__mount_user"]},password=${INI["network__mount_password"]} ${INI["network__mount_address"]} /music/Network/
+#    mount -t cifs -o sec=ntlm,ro,rsize=2048,wsize=4096,cache=strict,user=${INI["network__mount_user"]},password=${INI["network__mount_password"]} ${INI["network__mount_address"]} /music/Network/
 #add rsize=2048,wsize=4096,cache=strict because of usb (from raspyfi)
 fi
 
 # scan local music files once
-if [ "$INI__musicbox__scan_once" == "1" ]
+if [ "${INI["musicbox__scan_once"]}" == "1" ]
 then
     #set SCAN_ONCE = false
     sed -i -e "/^\[musicbox\]/,/^\[.*\]/ s|^\(scan_once[ \t]*=[ \t]*\).*$|\1false\r|" $CONFIG_FILE
 fi
 
 # scan local/networked music files if setting is true
-if [ "$INI__musicbox__scan_always" == "1" -o "$INI__musicbox__scan_once" == "1" ]
+if [ "${INI["musicbox__scan_always"]}" == "1" -o "${INI["musicbox__scan_once"]}" == "1" ]
 then
     log_progress_msg "Scanning music-files, please wait..."
     /etc/init.d/mopidy run local scan
@@ -210,9 +210,9 @@ fi
 #start mopidy
 /etc/init.d/mopidy start
 
-if [ "$INI__network__name" != "$CLEAN_NAME" -a "$INI__network__name" != "" ]
+if [ "${INI["network__name"]}" != "$CLEAN_NAME" -a "${INI["network__name"]}" != "" ]
 then
-    log_warning_msg "The new name of your MusicBox, $INI__network__name, is not ok! It should be max. 9 alphanumerical characters."
+    log_warning_msg "The new name of your MusicBox, ${INI["network__name"]}, is not ok! It should be max. 9 alphanumerical characters."
 fi
 
 # Print the IP address
@@ -224,17 +224,17 @@ fi
 # renice mopidy to 19, to have less stutter when playing tracks from spotify (at the start of a track)
 renice 19 `pgrep mopidy`
 
-if [ "$INI__musicbox__autoplay" -a "$INI__musicbox__autoplaywait" ]
+if [ "${INI["musicbox__autoplay"]}" -a "${INI["musicbox__autoplaywait"]}" ]
 then
-    log_progress_msg "Waiting $INI__musicbox__autoplaywait seconds before autoplay." "$NAME"
-    sleep $INI__musicbox__autoplaywait
-    log_progress_msg "Playing $INI__musicbox__autoplay" "$NAME"
-    mpc add "$INI__musicbox__autoplay"
+    log_progress_msg "Waiting ${INI["musicbox__autoplaywait"]} seconds before autoplay." "$NAME"
+    sleep ${INI["musicbox__autoplaywait"]}
+    log_progress_msg "Playing ${INI["musicbox__autoplay"]}" "$NAME"
+    mpc add "${INI["musicbox__autoplay"]}"
     mpc play
 fi
 
 
-# check and clean dirty bit of vfat partition not safely removed
+# check and clean dirty bit of vfat partition if not safely removed
 fsck /dev/mmcblk0p1 -v -a -w -p > /dev/null 2>&1 || true
 
 log_end_msg 0

--- a/filechanges/opt/musicbox/startup.sh
+++ b/filechanges/opt/musicbox/startup.sh
@@ -31,7 +31,7 @@ unset INI
 declare -A INI
 
 # ini vars to mopidy settings
-read_ini /tmp/settings.ini
+read_ini -nv /tmp/settings.ini
 
 rm /tmp/settings.ini > /dev/null 2>&1 || true
 

--- a/site/index.html
+++ b/site/index.html
@@ -42,21 +42,22 @@
     </head>
 <body>
 
-<img src="images/logo-small.png" width="340" class="logo" />
+<a href="index.html"><img src="images/pmblogo.png" class="logo" /></a>
 <div class="wrapper">
     <div class="social">
         <a href="https://www.facebook.com/raspberrypimusicbox" target="_blank"><img src="images/fb.png" /></a>
         <a href="https://twitter.com/pimusicbox" target="_blank"><img src="images/tw.png" /></a>
     </div>
-    <h1>Make your Pi stream!</h1>
-    <p>Pi MusicBox is the Swiss Army Knife of streaming music on the Raspberry Pi. With Pi MusicBox, you can create a cheap (Sonos-like) standalone streaming music player for Spotify and other music streams.<br/><br/>
-        Connect a 25$ Raspberry Pi to your (DIY) audio system, easily configure MusicBox and go! Control the music from your couch using a phone, tablet, laptop or PC, no tinkering required. <br/><br/>
-        Won't drain your battery when playing. The music won't stop if you play a game on your phone. AirPlay and DLNA streaming also included!</p>
+    <h1>Pi MusicBox</h1>
+    <h3>Make your Raspberry Pi stream!</h3>
+    <p>Welcome to the Swiss Army Knife of streaming music using the Raspberry Pi. With Pi MusicBox, you can create a cheap (Sonos-like) standalone streaming music player for Spotify, Google Music, SoundCloud, Webradio, Podcasts and other music from the cloud. Or from your own collection from a device in your network. It won't drain the battery of your phone when playing. The music won't stop if you play a game on your phone.<br/><br/>
+        Connect a 25$ Raspberry Pi to your (DIY) audio system, easily configure MusicBox and go! Control the music from your couch using a phone, tablet, laptop or PC, no tinkering required. AirPlay and DLNA streaming also included!<br/><br/>
+        </p>
     <br/>
     <h2> Features</h2>
         <ul>
             <li>
-                Headless audio player based on <a href="http://www.mopidy.com">Mopidy</a> (no need for a monitor), streaming music from Spotify, SoundCloud, Google Music, Podcasts (with iTunes, gPodder directories), MP3/OGG/FLAC/AAC, Webradio (with TuneIn, Dirble, AudioAddict, Soma FM directories), Subsonic.
+                Headless audio player based on <a href="http://www.mopidy.com">Mopidy</a> (no need for a monitor), streaming music from Spotify, SoundCloud, Google Music, Podcasts (with iTunes, gPodder directories), local and networked music files (MP3/OGG/FLAC/AAC), Webradio (with TuneIn, Dirble, AudioAddict, Soma FM directories), Subsonic.
             </li>
             <li>
                 Remote control it using a nice webinterface or using an MPD-client (like MPDroid for Android).
@@ -80,7 +81,7 @@
                 Last.FM scrobbling.
             </li>
             <li>
-                Several Pi soundcards supported (<a href="http://www.hifiberry.com">HifiBerry (DAC/Digi/+)</a>, <a href="http://www.iqaudio.com">IQ Audio</a>, )
+                Several Pi soundcards supported (<a href="http://www.hifiberry.com">HifiBerry (DAC/Digi/AMP/+)</a>, <a href="http://www.iqaudio.com">IQ Audio</a>, )
             </li>
        </ul>
         <div class="fadedline"></div>
@@ -113,7 +114,7 @@
                 <a href="http://mpd.wikia.com/wiki/Clients" target="_blank">MPD client</a> to connect.
             </li>
             <li>
-                Spotify <strong>Premium</strong> (Spotify Connect is NOT supported), Google Music (All Access) or SoundCloud account for streaming.
+                Spotify <strong>Premium</strong>, Google Music (All Access) or SoundCloud account for streaming.
             </li>
         </ul>
         <div class="fadedline"></div>
@@ -130,17 +131,18 @@
        </div>
        <div class="fadedline"></div>
         <h2>Download</h2>
-        <p>Here you can find an image for the SD Card for you Pi. It's around 266MB in (compressed) size; 950MB uncompressed (<a href="https://github.com/woutervanwijk/Pi-MusicBox/blob/master/changes.rst">changes</a>):<br/><br/>
+        <p>Here you can find an image for the SD Card for you Pi. It's around 290MB in (compressed) size; 950MB uncompressed (<a href="https://github.com/woutervanwijk/Pi-MusicBox/blob/master/changes.rst">changes</a>):<br/><br/>
             <ul>
 
 
-                <li><a href="http://dl.mopidy.com/musicbox0.5.3.zip">Download Pi MusicBox 0.5.3 via </a> <a href="http://www.rackspace.com">RackSpace</a> </li>
-                <li><a href="musicbox0.5.3.zip">Download directly from this site (slower)</a></li><br/>
+                <li><a href="http://dl.mopidy.com/musicbox0.6.zip">Download Pi MusicBox 0.6 via </a> <a href="http://www.rackspace.com">RackSpace</a> </li>
+                <li><a href="musicbox0.6.zip">Download directly from this site (slower)</a></li><br/>
 
 
             </ul>
-<!--      <a href="prerelease.html">Head overhere to download the latest prerelease-version! It has a lot of improvements and it's also quite stable!</a><br/><br/> 
--->               <br/> 
+  <!--   <a href="prerelease.html">Head overhere to download the latest prerelease-version, including support for the Pi 2!</a><br/><br/>
+-->
+              <br/>
     This can take a while, so in the meantime, please spread the word!<br/><br/>
     <div style="height:32px">
         <span class='st_facebook_large' displayText='Facebook'></span>

--- a/site/prerelease.html
+++ b/site/prerelease.html
@@ -3,8 +3,8 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html;charset=UTF-8" />
         <title>Pi MusicBox - A Spotify, SoundCloud, Google Music player for the Raspberry Pi, with remote control</title>
-        <meta name="description" content="Connect Spotify, SoundCloud, Google Music to your audio set using the Raspberry Pi and control it from your couch! An easy to use SD-image for the Pi. AirPlay streaming included!">
-        <meta name="keywords" content="spotify, player, music, musicbox, raspberry pi,free, open source, connect, remote, multiroom, audio, control, soundcloud, google music, webradio, radio, stream, mpd, usb dac, audioset, audioplayer, mp3, ogg, flac, airtunes, airplay, last.fm, scrobbling, hifi, stereo, remote, mashup, wifi, headless, web interface, internet radio, headphones, usb speakers">
+        <meta name="description" content="Easily play Spotify, SoundCloud, Google Music, Podcasts, Webradio, Subsonic on your (DIY) audio system using the Raspberry Pi and control it from your couch! AirPlay and DLNA streaming included!">
+        <meta name="keywords" content="spotify, player, music, musicbox, raspberry pi,free, sonos, subsonic, streaming, audo system, open source, connect, remote, soundcloud, google music, webradio, podcasts, radio, mpd, usb dac, airtunes, airplay, dlna, last.fm, hifi, headless, web interface">
         <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
         <link rel="stylesheet" href="css/jquery.fancybox.css" type="text/css" media="screen" />
         <script type="text/javascript" src="js/jquery.fancybox.pack.js"></script>
@@ -42,7 +42,7 @@
     </head>
 <body>
 
-<a href="/"><img src="images/logo-small.png" width="340" class="logo" /></a>
+<a href="index.html"><img src="images/pmblogo.png" class="logo" /></a>
 <div class="wrapper">
     <div class="social">
         <a href="https://www.facebook.com/raspberrypimusicbox" target="_blank"><img src="images/fb.png" /></a>
@@ -50,156 +50,30 @@
     </div>
     <h1>Pi MusicBox Prerelease</h1>
         <p>
-            MusicBox 0.5.2 beta (15 december 2014) contains the following improvements:
+            MusicBox 0.6RC contains the following improvements:
         </p>
             <ul>
-            <li>Wifi not coming up bug fixed</li>
-            <li>Resize bug fixed</li>
-            <li>Webinterface stops streams instead of pause</li>
-            <li>Fixed Spotify stuttering</li>
-            <li>Fixed Spotify Browse</li>
-            <li>Button to easily save current stream to favorites</li>
+            <li>Enhanced support for Raspberry Pi 2</li>
+            <li>Updated kernel</li>
+            <li>New version of the webinterface</li>
+            <li>Better support for soundcards (HifiBerry AMP), USB Audio fixed</li>
+            <li>Other bugfixes</li>
             </ul>
         <br/>
         
         <br/>
-        <p>
-            Earlier versions of MusicBox contained the following improvements:
-        </p>
-            <ul>
-            <li>Added audioaddict extension</li>
-            <li>Shairport-sync instead of Shairport. AirPlay audio now syncs to e.g. a video</li>
-            <li>Alsamixer extension included for hardware mixers (no gui, only in ini file)</li>
-            <li>Removed fastclick to prevent accidental clicks in the webinterface</li>
-            <li>Replaced gmediarender with upmpdcli for better and more stable upnp streaming support.</li>
-            <li>Brand new Google Music, including albums, browse, search</li>
-            <li>Support for more i2s audiocards</li>
-            <li>More responsive mopidy, version 0.19.4</li>
-            <li>Nicer webclient with new homescreen, better coverart</li>
-            <li>Play streams from youtube, spotify, soundcloud, radio by pasting an url</li>
-            <li>Search music per service</li>
-            <li>Youtube integration</li>
-            </ul>
+
         <div class="fadedline"></div>
         <h3> Instructions</h3>
-        <ul>
-            <li>
-                Download the image. It's about 262MB in (compressed) size; 1GB uncompressed.<br/><br/>
+
+                Download the image. It's about 292MB in (compressed) size; 1GB uncompressed.<br/><br/>
+
                 <ul>
-<!--                    <li><a href="http://dl.mopidy.com/musicbox0.5beta2.zip">musicbox0.5beta2.zip (Fast mirror, Rackspace)</a> </li><br/> -->
-                    <li><a href="musicbox0.5.2beta.zip">musicbox0.5.2beta.zip (from this site)</a></li>
+                    <li><a href="http://dl.mopidy.com/musicbox0.6RC.zip">musicbox0.6RC.zip (Fast mirror, Rackspace)</a> </li><br/>
+                    <li><a href="musicbox0.6RC.zip">musicbox0.6RC.zip (from this site)</a></li>
                 </ul><br/>
-                 This can take a while, so spread the word in the meantime, please spread the word!<br/><br/>
-  <span class='st_facebook_large' displayText='Facebook'></span>
-        <span class='st_twitter_large' displayText='Tweet'></span>
-        <span class='st_googleplus_large' displayText='Google +'></span>
-        <span class='st_reddit_large' displayText='Reddit'></span>
-        <span class='st_digg_large' displayText='Digg'></span>
-        <span class='st_email_large' displayText='Email'></span>
-        <span class='st_pinterest_large' displayText='Pinterest'></span>
-        <span class='st_sharethis_large' displayText='ShareThis'></span>  <br/>     <br/>
-            </li>
-        <div class="fadedline"></div>
-        <h4>Configuration</h4>
-        <ol>
-            <li>
-                You can edit all settings in the new settings page from the webclient. To access it, you need a network connection. To enable Wifi, you can either first connect the Pi using a cable and use the settings page, or fill in the wifi-settings in the ini file on the SD Card. For that:
-            </li>
-            <li>
-                Open the contents of the 'config' folder of SD-Card in your
-                Finder/Explorer.
-            </li>
-            <li>
-                Add your Wifi network and password to the file (and other things you would like to edit)
-                <code>
-                    settings.ini
-                </code>
-               It has instructions on what to put where.
-            </li>
-            <li>
-                MusicBox will autodetect usb audiocards/speakers/boxes and hdmi.
-                It's possible to override this in the settings. For example if you want to use analog out while having hdmi connected.
-            </li>
-        </ol>
-        <br />
+                For installation and configuration, look at the <a href="index.html">homepage</a><br/><br/>
 
-    <p>Detailed instructions can be found in the <a href="MusicBox_Manual.pdf">Manual</a>. But it's written for MusicBox 0.4...</p><br/>
-                <div class="fadedline"></div>
-        <h4>Start me up!</h4>
-        <ol>
-            <li>
-                Put the card in the Pi
-            </li>
-            <li>
-                Connect cables (You don't have to connect a monitor to the Pi if you
-                don't want to)
-            </li>
-            <li>
-                To use Wifi and USB-Audio you have to plugin the devices before you
-                start the Pi. Restart if you plug them in later.
-            </li>
-            <li>
-                Power on your Pi
-            </li>
-            <li>
-                              Wait for a while... So in the meantime, follow us!<br/><br/>
-                <a href="https://twitter.com/pimusicbox" class="twitter-follow-button" data-show-count="false" data-size="large" data-dnt="true">Follow @pimusicbox on Twitter</a><br/><br/>
-            <iframe src="//www.facebook.com/plugins/like.php?href=https%3A%2F%2Fdevelopers.facebook.com%2Fdocs%2Fplugins%2F&amp;width=250&amp;layout=standard&amp;action=recommend&amp;show_faces=true&amp;share=true&amp;height=80" scrolling="no" frameborder="0" style="border:none; overflow:hidden; width:250px; height:80px;" allowTransparency="true"></iframe>
-
-<script>
-                ! function(d, s, id) {
-                    var js, fjs = d.getElementsByTagName(s)[0], p = /^http:/.test(d.location) ? 'http' : 'https';
-                    if (!d.getElementById(id)) {
-                        js = d.createElement(s);
-                        js.id = id;
-                        js.src = p + '://platform.twitter.com/widgets.js';
-                        fjs.parentNode.insertBefore(js, fjs);
-                    }
-                }(document, 'script', 'twitter-wjs');
-            </script>
-
-            </li>
-        </ol>
-        <br />
-
-                <div class="fadedline"></div>
-        <h4>Accessing the music</h4>
-        <ol>
-            <li>
-                Point your browser to the Pi. Depending on your network and computers,
-                it will be available at this address:
-                <code>
-                     <a href="http://musicbox.local/">http://musicbox.local</a>
-                </code>
-            </li>
-            <li>
-                Most OS X/iOS and Windows devices probably will find it immediately. If it doesn't work, you could try to
-                install Apple Bonjour/iTunes in Windows to make it work. Linux should also work if Avahi or Samba/Winbind is installed.
-            </li>
-            <li>
-                Using Android, you have to point your browser to the MusicBox using the IP-address of your Pi, e.g.
-                <code>
-                    http://192.168.1.5/
-                </code> (fill in your own!).
-                There is no way to change that for now, unless Android would support it,
-                The IP-address is printed on the screen when
-                MusicBox is started. Connect a monitor/tv to find out. Or use a network/bonjour scanning utility.
-            </li>
-        </ol>
-        <div class="fadedline"></div>
-    <h2>Support &amp; Contact</h2>
-
-     <p>Please refer to the <a href="faq.html">Frequently Asked Questions</a> and the <a href="MusicBox_Manual.pdf">Manual</a> before asking questions. </p>
-        <br />
-    You can discuss features and problems on the <a href="https://groups.google.com/forum/?fromgroups=#!forum/mopidy">Google Group (maillist/forum) of Mopidy</a>. Please report problems about MusicBox itself at <a href="https://github.com/woutervanwijk/Pi-MusicBox">the repo at Github</a>. On <a href="http://www.facebook.com/raspberrypimusicbox">FaceBook</a> or <a href="https://twitter.com/pimusicbox">Twitter</a>, you can contact us. You can also try the
-            <code>
-                #mopidy
-            </code>
-            channel on <a href="http://webchat.freenode.net/">Freenode</a>,
-             or the <a href="http://www.raspberrypi.org/phpBB3/">Raspberry
-            Pi forums</a>.<br/><br/>
-        If you wish to contact us you can use the Facebook/Twitter links at the top of the page.
-        <br />
         <div class="fadedline"></div>
 </div>
 


### PR DESCRIPTION
Allows special characters to be used in section names of settings.ini.

Adds support for configuring extensions like [local-sqlite] properly.

Note that support for the search_limit parameter requires Mopidy-Local-SQLite >= 0.9.2 (run pip install --upgrade Mopidy-Local-SQLite to upgrade)

This is a rebase of https://github.com/woutervanwijk/Pi-MusicBox/pull/234 on to /upstream/develop.
