### PR TITLE
Improve autoplay: poll Mopidy until connection is accepted

### DIFF
--- a/filechanges/boot/config/settings.ini
+++ b/filechanges/boot/config/settings.ini
@@ -189,11 +189,11 @@ resize_once = true
 scan_always = true
 
 # MusicBox can automatically start playing a stream/song after startup.
-# It will wait a number of seconds before trying to do so for the system to first become ready. 
+# It will wait up to autoplaymaxwait seconds before trying to do so for the system to first become ready.
 # The wait required varies per device, network and configuration so if it doesn't work then increase the time.
 # e.g. autoplay = http://nprdmp.ic.llnwd.net/stream/nprdmp_live01_mp3 or local:track:MusicBox/Music%20File.mp3 (on the SD Card)
 autoplay = 
-autoplaywait = 60
+autoplaymaxwait = 60
 
 # -------------
 # | Streaming |

--- a/filechanges/opt/musicbox/startup.sh
+++ b/filechanges/opt/musicbox/startup.sh
@@ -228,7 +228,7 @@ if [ "$INI__musicbox__autoplay" -a "$INI__musicbox__autoplaymaxwait" ]
 then
     if ! [[ $INI__musicbox__autoplaymaxwait =~ ^[0-9]*+$ ]] ; then
         log_progress_msg "Value specified for 'autoplaymaxwait' is not a number, defaulting to 60" "$NAME"
-        $INI__musicbox__autoplaymaxwait = 60
+        INI__musicbox__autoplaymaxwait=60
     fi
     log_progress_msg "Waiting for Mopidy to accept connections..." "$NAME"
     waittime=0

--- a/filechanges/opt/musicbox/startup.sh
+++ b/filechanges/opt/musicbox/startup.sh
@@ -226,6 +226,10 @@ renice 19 `pgrep mopidy`
 
 if [ "$INI__musicbox__autoplay" -a "$INI__musicbox__autoplaymaxwait" ]
 then
+    if ! [[ $INI__musicbox__autoplaymaxwait =~ ^[0-9]*+$ ]] ; then
+        log_progress_msg "Value specified for 'autoplaymaxwait' is not a number, defaulting to 60" "$NAME"
+        $INI__musicbox__autoplaymaxwait = 60
+    fi
     log_progress_msg "Waiting for Mopidy to accept connections..." "$NAME"
     waittime=0
     while ! nc -q 1 localhost 6600 </dev/null;

--- a/filechanges/opt/musicbox/startup.sh
+++ b/filechanges/opt/musicbox/startup.sh
@@ -224,13 +224,26 @@ fi
 # renice mopidy to 19, to have less stutter when playing tracks from spotify (at the start of a track)
 renice 19 `pgrep mopidy`
 
-if [ "$INI__musicbox__autoplay" -a "$INI__musicbox__autoplaywait" ]
+if [ "$INI__musicbox__autoplay" -a "$INI__musicbox__autoplaymaxwait" ]
 then
-    log_progress_msg "Waiting $INI__musicbox__autoplaywait seconds before autoplay." "$NAME"
-    sleep $INI__musicbox__autoplaywait
-    log_progress_msg "Playing $INI__musicbox__autoplay" "$NAME"
-    mpc add "$INI__musicbox__autoplay"
-    mpc play
+    log_progress_msg "Waiting for Mopidy to accept connections..." "$NAME"
+    waittime=0
+    while ! nc -q 1 localhost 6600 </dev/null;
+        do
+            sleep 1;
+            waittime=$((waittime+1));
+            if [ $waittime -gt $INI__musicbox__autoplaymaxwait ]
+                then
+                    log_progress_msg "Timeout waiting for Mopidy to start, aborting" "$NAME"
+                    break;
+            fi
+        done
+    if [ $waittime -le $INI__musicbox__autoplaymaxwait ]
+        then
+            log_progress_msg "Mopidy startup complete, playing $INI__musicbox__autoplay" "$NAME"
+            mpc add "$INI__musicbox__autoplay"
+            mpc play
+    fi
 fi
 
 


### PR DESCRIPTION
Play autoplay track as soon as Mopidy is ready to accept connections.

Based on checking Mopidy MPD server readiness for accepting connections as explained at https://docs.mopidy.com/en/latest/running/ and http://mpd.wikia.com/wiki/Music_Player_Daemon_HOWTO_Troubleshoot