### PR TITLE
use guest account when trying to mount CIFS share without specifying a username

### DIFF
--- a/filechanges/opt/musicbox/startup.sh
+++ b/filechanges/opt/musicbox/startup.sh
@@ -185,7 +185,13 @@ if [ "$INI__network__mount_address" != "" ]
 then
     #mount samba share, readonly
     log_progress_msg "Mounting Windows Network drive..." "$NAME"
-    mount -t cifs -o sec=ntlm,ro,user=$INI__network__mount_user,password=$INI__network__mount_password "$INI__network__mount_address" /music/Network/
+    if [ "$INI__network__mount_user" != "" ]
+    then
+        SMB_CREDENTIALS=user=$INI__network__mount_user,password=$INI__network__mount_password
+    else
+        SMB_CREDENTIALS=guest
+    fi
+    mount -t cifs -o sec=ntlm,ro,$SMB_CREDENTIALS "$INI__network__mount_address" /music/Network/
 #    mount -t cifs -o sec=ntlm,ro,rsize=2048,wsize=4096,cache=strict,user=$INI__network__mount_user,password=$INI__network__mount_password $INI__network__mount_address /music/Network/
 #add rsize=2048,wsize=4096,cache=strict because of usb (from raspyfi)
 fi


### PR DESCRIPTION
My Samba Server (4.1.16) does not allow connection with empty username and password though it is configured to allow guest access.

I think the mount.cifs option "guest" should be used when trying to connect anonymously